### PR TITLE
Add a 15min timeout to update-service systemd config.

### DIFF
--- a/templates/tinypilot-updater.systemd.j2
+++ b/templates/tinypilot-updater.systemd.j2
@@ -11,6 +11,8 @@ Environment=PYTHONPATH={{ tinypilot_dir }}/app
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=tinypilot-update-svc
+TimeoutSec=900
+KillSignal=SIGKILL
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
[Demo video](https://www.loom.com/share/f69768385f3e4aa0a22816dc465448bc).

### What I learned
I initially wanted to to add [`RuntimeMaxSec`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#RuntimeMaxSec=) to the systemd config to kill the process after 15min, but because we use `Type=oneshot` the service is never actually running. It's only ever starting then not running. So `RuntimeMaxSec` would have no effect.

I went with the original (wise) suggestion:
> We should add TimeoutSec (and maybe KillMode) to the TinyPilot updater service systemd config so that systemd kills any stuck update processes that last longer than 15 minutes.

Fixes #130 