### PR TITLE
Update location of TinyPilot git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/tiny-pilot/ansible-role-tinypilot.svg?style=svg)](https://circleci.com/gh/tiny-pilot/ansible-role-tinypilot)
 [![License](http://img.shields.io/:license-mit-blue.svg?style=flat-square)](LICENSE)
 
-Ansible role for [TinyPilot KVM](https://github.com/mtlynch/tinypilot).
+Ansible role for [TinyPilot KVM](https://github.com/tiny-pilot/tinypilot).
 
 ## Role Variables
 
@@ -12,7 +12,7 @@ Available variables are listed below, along with default values (see [defaults/m
 ```yaml
 tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
-tinypilot_repo: https://github.com/mtlynch/tinypilot.git
+tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
 tinypilot_repo_branch: master
 tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
-tinypilot_repo: https://github.com/mtlynch/tinypilot.git
+tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
 tinypilot_repo_branch: master
 # Port on which TinyPilot frontend listens (accessible from other hosts on the
 # network).

--- a/files/update
+++ b/files/update
@@ -12,5 +12,5 @@ set -e
 curl \
   --silent \
   --show-error \
-  https://raw.githubusercontent.com/mtlynch/tinypilot/master/quick-install | \
+  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/quick-install | \
     bash -


### PR DESCRIPTION
I moved TinyPilot from mtlynch/tinypilot to tiny-pilot/tinypilot, so this updates all the URLs to match.