### PR TITLE
Move uStreamer variables out of tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: install uStreamer
   import_tasks: ustreamer.yml
+  tags:
+    - ustreamer
 
 - name: install nginx
   import_tasks: nginx.yml

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -11,7 +11,6 @@
   import_role:
     name: ansible-role-nginx
   vars:
-    ustreamer_port: 8001
     nginx_upstreams:
       - name: tinypilot
         servers:

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -2,8 +2,3 @@
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
-  vars:
-    ustreamer_interface: '127.0.0.1'
-    ustreamer_port: 8001
-    ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
-    ustreamer_repo_version: "v3.26"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,8 @@
 # relies on the tinypilot user being named "tinypilot" so changing this value
 # will break updates.
 tinypilot_user: tinypilot
+
+ustreamer_interface: '127.0.0.1'
+ustreamer_port: 8001
+ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
+ustreamer_repo_version: 'v3.26'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,6 +4,9 @@
 # will break updates.
 tinypilot_user: tinypilot
 
+# uStreamer variables are placed here, instead of in `defaults/main.yml`,
+# in order to elevate their variable precedence. These variables will now
+# override the default variables in the uStreamer role.
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git


### PR DESCRIPTION
This was trickier than expected. I wasn't able to move the ustreamer vars to `defaults/main.yml` and instead I moved them to `vars/main.yml`. The reason being is [ansible's variable precedence](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#understanding-variable-precedence).

A role's default variables has the lowest priority. So defining variables in `ansible-role-tinypilot/defaults/main.yml` has the same priority level as variables in `ansible-role-ustreamer/defaults/main.yml`. And the [default variables of the last role to be imported takes precedence](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#id13).

So defining ustreamer variables in `ansible-role-tinypilot/defaults/main.yml` just didn't take effect. But because `ansible-role-tinypilot/vars/main.yml` has a higher priority, it finally worked. This change still allows us to avoid redefining variables inside tasks.

[Demo video](https://www.loom.com/share/7877d5a1c80a488a8f16f877f2709f4e).

Fixes #140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/141)
<!-- Reviewable:end -->
