### PR TITLE
Fix asset caching to avoid redundant requests

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -54,7 +54,7 @@
           location / {
             proxy_pass http://tinypilot;
           }
-          location ~* ^/.+\.(html|js|js.map|css)$ {
+          location ~* ^/.+\.(html|js|js.map|css|woff|woff2)$ {
             root "{{ tinypilot_dir }}/app/static";
 
             # Disable caching

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -57,12 +57,14 @@
           location ~* ^/.+\.(html|js|js.map|css|woff|woff2)$ {
             root "{{ tinypilot_dir }}/app/static";
 
-            # Disable caching
+            # We cache assets to prevent the browser from making redundant
+            # requests to the same files while loading the page. (Observed on
+            # Chrome 91.) We don’t want caching otherwise, though, in order to
+            # avoid stale files after users update their device. Note, that in
+            # addition to `max-age`, the browser’s caching behaviour is relative
+            # to the `Last-Modified` header, so we make that seem recent.
             add_header Last-Modified $date_gmt;
-            add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-            if_modified_since off;
-            expires off;
-            etag off;
+            add_header Cache-Control 'public, max-age=10s';
           }
           location ~* ^/.+\.(jpg|jpeg|png|ico)$ {
             root "{{ tinypilot_dir }}/app/static";

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -54,7 +54,7 @@
           location / {
             proxy_pass http://tinypilot;
           }
-          location ~* ^/.+\.(html|js|js.map|css|woff|woff2)$ {
+          location ~* ^/.+\.(html|js|js.map|css)$ {
             root "{{ tinypilot_dir }}/app/static";
 
             # We cache assets to prevent the browser from making redundant


### PR DESCRIPTION
Fixes part 1 of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/144.

The resulting behaviour should be that Chrome doesn’t do redundant requests for CSS files anymore. As discussed in the linked issue, we can achieve this via caching. We must avoid by all means, however, that the browser serves from the cache after users perform a device udpate, because that can lead to funky behaviour client-side. Therefore, the caching duration is intentionally short.

## Remarks
- Remove unnecessary caching directives:
  - The `Expires` header will be ignored anyways if `max-age` is present, so we don’t need to configure it. ([Source](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires))
  - If the [`etag`](http://nginx.org/en/docs/http/ngx_http_core_module.html#etag) and [`if_modified_since`](http://nginx.org/en/docs/http/ngx_http_core_module.html#if_modified_since) directives are not specified, nginx will enable both by default. I don’t see any harm in doing this: if the browser wants to probe the server to check whether there is something new, we can just let that happen.
- Setting the `Last-Modified` to a recent time is actually crucial, [due to heuristic caching strategies](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.2.2). The longer a resource hasn’t been modified, the more likely it is for the browser to defer cache invalidation. Interestingly, the `max-age` value alone doesn’t seem to be enough to enforce cache invalidation reliably, I could observe this when testing.
- I set `Cache-Control` to [`public`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1) because I think it should be okay for assets to be stored in a shared client-side cache. The assets are not user-specific after all.

## Measurement of transferred assets

(`.css`, `.js` and `.woff2` files; for Pro.)

|  | Before | After |
|--|--|--|
| Number of requests | 128 | 21 |
| kB transferred | 503 kB | 238 kB |

## Sample response (after)
```
GET http://tinypilot/css/cursors.css

Accept-Ranges: bytes
Cache-Control: public, max-age=10s
Connection: keep-alive
Content-Length: 671
Content-Type: text/css
Date: Mon, 19 Jul 2021 08:12:37 GMT
ETag: "60e69367-29f"
Last-Modified: Monday, 19-Jul-2021 08:12:37 GMT
Server: nginx/1.14.2
```

## Sample response (before)
```
GET http://tinypilot/css/cursors.css

Accept-Ranges: bytes
Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0
Connection: keep-alive
Content-Length: 671
Content-Type: text/css
Date: Mon, 19 Jul 2021 08:42:41 GMT
Last-Modified: Monday, 19-Jul-2021 08:42:41 GMT
Server: nginx/1.14.2
```