### PR TITLE
Serve font files via nginx

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -54,7 +54,7 @@
           location / {
             proxy_pass http://tinypilot;
           }
-          location ~* ^/.+\.(html|js|js.map|css)$ {
+          location ~* ^/.+\.(html|js|js.map|css|woff|woff2)$ {
             root "{{ tinypilot_dir }}/app/static";
 
             # Disable caching


### PR DESCRIPTION
While working on https://github.com/tiny-pilot/ansible-role-tinypilot/issues/144, I noticed that [our font files](https://github.com/tiny-pilot/tinypilot/tree/master/app/static/third-party/fonts) are not served via nginx. We actually had just forgotten about this back then, [when we started serving font files locally](https://github.com/tiny-pilot/tinypilot/pull/575).