### PR TITLE
Port over Flask app settings file from TinyPilot Pro.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
 tinypilot_pip_args: ""
+tinypilot_app_settings_file: "{{ tinypilot_dir }}/app_settings.cfg"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,17 @@
   notify:
     - restart TinyPilot service
 
+- name: create TinyPilot app settings
+  template:
+    src: tinypilot-app-settings.cfg.j2
+    dest: "{{ tinypilot_app_settings_file }}"
+    owner: "{{ tinypilot_user }}"
+    group: "{{ tinypilot_group }}"
+  notify:
+    - restart TinyPilot service
+  tags:
+    - app-settings
+
 - name: fix TinyPilot folder permissions
   file:
     path: "{{ tinypilot_dir }}"
@@ -132,6 +143,8 @@
   notify:
     - reload TinyPilot systemd config
     - restart TinyPilot service
+  tags:
+    - systemd-config
 
 - name: enable systemd TinyPilot service file
   systemd:

--- a/templates/tinypilot-app-settings.cfg.j2
+++ b/templates/tinypilot-app-settings.cfg.j2
@@ -1,0 +1,5 @@
+# This configuration file is an actual Python file. Only variables in uppercase
+# are recognized as config keys.
+
+KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
+MOUSE_PATH = '{{ tinypilot_mouse_interface }}'

--- a/templates/tinypilot.systemd.j2
+++ b/templates/tinypilot.systemd.j2
@@ -10,8 +10,7 @@ WorkingDirectory={{ tinypilot_dir }}
 ExecStart={{ tinypilot_dir }}/venv/bin/python app/main.py
 Environment=HOST={{ tinypilot_interface }}
 Environment=PORT={{ tinypilot_port }}
-Environment=KEYBOARD_PATH={{ tinypilot_keyboard_interface }}
-Environment=MOUSE_PATH={{ tinypilot_mouse_interface }}
+Environment=APP_SETTINGS_FILE={{ tinypilot_app_settings_file }}
 {% if tinypilot_enable_debug_logging %}
 Environment=DEBUG=1
 {% endif %}


### PR DESCRIPTION
Move `KEYBOARD_PATH` and `MOUSE_PATH` environment variables into a Flask app settings file.

Fixes https://github.com/tiny-pilot/ansible-role-tinypilot/issues/142

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/148)
<!-- Reviewable:end -->
