### PR TITLE
Disable nginx buffering for uStreamer

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -46,6 +46,9 @@
             proxy_pass http://ustreamer;
           }
           location /stream {
+            postpone_output 0;
+            proxy_buffering off;
+            proxy_ignore_headers X-Accel-Buffering;
             proxy_pass http://ustreamer;
           }
           location /snapshot {


### PR DESCRIPTION
Buffering in nginx can cause delays in the video stream, so we want to disable all buffering for the uStreamer /stream route.

Fixes #153

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/154)
<!-- Reviewable:end -->
