### PR TITLE
Patch keyboard HID module.

### DIFF
--- a/files/init-usb-gadget
+++ b/files/init-usb-gadget
@@ -72,6 +72,10 @@ D=$(mktemp)
   echo -ne \\xC0            # End Collection
 } >> "$D"
 cp "$D" "${KEYBOARD_FUNCTIONS_DIR}/report_desc"
+# Enable pre-boot events (if the gadget driver supports it).
+if [[ -f "${KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint" ]]; then
+  echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"
+fi
 
 # Mouse
 MOUSE_FUNCTIONS_DIR="functions/hid.mouse"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,3 +15,8 @@
     daemon_reload: yes
     # Never run automatically.
     enabled: no
+
+- name: start usb-gadget service
+  service:
+    name: usb-gadget
+    state: started

--- a/tasks/install_usb_gadget.yml
+++ b/tasks/install_usb_gadget.yml
@@ -65,6 +65,24 @@
     mode: '0644'
   register: usb_gadget_template
 
+- name: patch HID module
+  get_url:
+    url: https://storage.googleapis.com/jason-tinypilotkvm/usb_f_hid.ko
+    dest: /lib/modules/{{ ansible_kernel }}/kernel/drivers/usb/gadget/function/usb_f_hid.ko
+    mode: '0664'
+  when: ansible_kernel is version('5.15', '<') and ansible_kernel is version('5.10', '>=')
+
+- name: patch usb-gadget initializer
+  ansible.builtin.lineinfile:
+    path: "{{ tinypilot_privileged_dir }}/init-usb-gadget"
+    line: 'echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"'
+    # Either replace the line this regex is found on.
+    regex: ^{{ 'echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"' | regex_escape() }}
+    # Or insert the line after this regex is found.
+    insertafter: ^{{ 'mkdir -p "$KEYBOARD_FUNCTIONS_DIR"' | regex_escape() }}$
+    # Otherwise add the line to the EOF.
+  when: ansible_kernel is version('5.15', '<') and ansible_kernel is version('5.10', '>=')
+
 - name: enable systemd usb-gadget initializer service file
   systemd:
     name: usb-gadget

--- a/tasks/install_usb_gadget.yml
+++ b/tasks/install_usb_gadget.yml
@@ -81,7 +81,7 @@
     # Or insert the line after this regex is found.
     insertafter: ^{{ 'mkdir -p "$KEYBOARD_FUNCTIONS_DIR"' | regex_escape() }}$
     # Otherwise add the line to the EOF.
-  when: ansible_kernel is version('5.15', '<') and ansible_kernel is version('5.10', '>=')
+  when: ansible_kernel is version('5.10', '>=')
 
 - name: enable systemd usb-gadget initializer service file
   systemd:

--- a/tasks/install_usb_gadget.yml
+++ b/tasks/install_usb_gadget.yml
@@ -65,23 +65,16 @@
     mode: '0644'
   register: usb_gadget_template
 
-- name: patch HID module
+# This custom USB kernel module fixes compatibility issues in pre-boot for OS X
+# systems. The patch already exists in kernal versions >= 5.15.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/151
+- name: patch USB kernel module
   get_url:
-    url: https://storage.googleapis.com/jason-tinypilotkvm/usb_f_hid.ko
+    url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
     dest: /lib/modules/{{ ansible_kernel }}/kernel/drivers/usb/gadget/function/usb_f_hid.ko
     mode: '0664'
+    checksum: sha256:45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7
   when: ansible_kernel is version('5.15', '<') and ansible_kernel is version('5.10', '>=')
-
-- name: patch usb-gadget initializer
-  ansible.builtin.lineinfile:
-    path: "{{ tinypilot_privileged_dir }}/init-usb-gadget"
-    line: 'echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"'
-    # Either replace the line this regex is found on.
-    regex: ^{{ 'echo 1 > "${KEYBOARD_FUNCTIONS_DIR}/no_out_endpoint"' | regex_escape() }}
-    # Or insert the line after this regex is found.
-    insertafter: ^{{ 'mkdir -p "$KEYBOARD_FUNCTIONS_DIR"' | regex_escape() }}$
-    # Otherwise add the line to the EOF.
-  when: ansible_kernel is version('5.10', '>=')
 
 - name: enable systemd usb-gadget initializer service file
   systemd:

--- a/tasks/install_usb_gadget.yml
+++ b/tasks/install_usb_gadget.yml
@@ -65,19 +65,48 @@
     mode: '0644'
   register: usb_gadget_template
 
-# This custom USB kernel module fixes compatibility issues in pre-boot for OS X
-# systems. The patch already exists in kernal versions >= 5.15.
-# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/151
-- name: patch USB kernel module
-  get_url:
-    url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
-    dest: /lib/modules/{{ ansible_kernel }}/kernel/drivers/usb/gadget/function/usb_f_hid.ko
-    mode: '0664'
-    checksum: sha256:45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7
-  when: ansible_kernel is version('5.15', '<') and ansible_kernel is version('5.10', '>=')
-
 - name: enable systemd usb-gadget initializer service file
   systemd:
     name: usb-gadget
     enabled: yes
     daemon_reload: "{{ usb_gadget_template.changed }}"
+
+# This custom USB HID kernel module fixes compatibility issues in pre-boot for
+# OS X systems. The patch already exists in kernal versions >= 5.15.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/151
+- name: check the HID module file
+  ansible.builtin.stat:
+    path: /lib/modules/{{ ansible_kernel }}/kernel/drivers/usb/gadget/function/usb_f_hid.ko
+    checksum_algorithm: sha256
+  register: hid_module_stat
+
+- name: save whether the HID module should be patched
+  set_fact:
+    patch_hid_module: >-
+      {{ ansible_kernel is version('5.15', '<')
+         and ansible_kernel is version('5.10', '>=')
+         and hid_module_stat.stat.checksum != '45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7' }}
+
+- name: ensure HID module is not in use
+  service:
+    name: usb-gadget
+    state: stopped
+  when: patch_hid_module
+
+- name: unload HID module
+  command: modprobe --remove usb_f_hid
+  when: patch_hid_module
+
+- name: patch HID module
+  get_url:
+    url: https://github.com/tiny-pilot/hid-backport/raw/master/bin/usb_f_hid.ko
+    dest: "{{ hid_module_stat.stat.path }}"
+    mode: '0644'
+    force: yes
+  when: patch_hid_module
+
+- name: load HID module
+  command: modprobe usb_f_hid
+  when: patch_hid_module
+  notify:
+    - start usb-gadget service


### PR DESCRIPTION
The patched HID module allows a Mac to recognize the TinyPilot keyboard in pre-boot (i.e. login screen).

The [patch](https://github.com/raspberrypi/linux/commit/d7428bc26fc767942c38d74b80299bcd4f01e7cb) is already included kernel versions [`>= 5.15`](https://github.com/raspberrypi/linux/commits/rpi-5.15.y/drivers/usb/gadget/function). However, the latest LTS kernel is version `5.10`. This PR installs the patched HID module on kernel versions `>=5.10` and `<5.15`.

This PR does the following:
1. Downloads and installs the patched `usb_f_hid.ko` module ([here](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/b7e7f89983c27bea88452d8748b96fbb2a0db8f7/tasks/install_usb_gadget.yml#L68-L73)).
2. Updates the USB gadget initializer by adding an additional `no_out_endpoint` HID function ([here](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/b7e7f89983c27bea88452d8748b96fbb2a0db8f7/tasks/install_usb_gadget.yml#L75-L84)). This HID function is only supported after the patch. We cannot add this function without the patched module.

Fixes #151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/155)
<!-- Reviewable:end -->
