### PR TITLE
Support debian bullseye

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,10 @@
 - name: Converge
   hosts: all
   tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: true
+        cache_valid_time: 600
     - name: "Include ansible-role-tinypilot"
       include_role:
         name: "ansible-role-tinypilot"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+  - name: debian11
+    image: geerlingguy/docker-debian11-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   log: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,16 +16,19 @@
       - git
       - python3-venv
       - sudo
+    can_install_pip3: >-
+      {{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('11', '>='))
+         or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')) }}
 
-- name: collect Debian and Ubuntu specific TinyPilot required apt packages
+- name: add pip to required apt packages
   set_fact:
     tinypilot_packages: "{{ tinypilot_packages }} + ['python-pip']"
-  when: ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version != '20.04')
+  when: not can_install_pip3
 
-- name: collect Ubuntu 20.04 specific TinyPilot required apt packages
+- name: add pip3 to required apt packages
   set_fact:
     tinypilot_packages: "{{ tinypilot_packages }} + ['python3-pip']"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '20.04'
+  when: can_install_pip3
 
 - name: install TinyPilot pre-requisite packages
   apt:


### PR DESCRIPTION
This PR allows TinyPilot to be successfully installed on a device running debian bullseye. [Demo video](https://www.loom.com/share/4cc2caa565484a178b186537bf4e7ed6).

Fixes #143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/158)
<!-- Reviewable:end -->
