### PR TITLE
Ensure stat checksum is defined.

### DIFF
--- a/tasks/install_usb_gadget.yml
+++ b/tasks/install_usb_gadget.yml
@@ -92,6 +92,7 @@
     patch_hid_module: >-
       {{ ansible_kernel is version('5.15', '<')
          and ansible_kernel is version('5.10', '>=')
+         and hid_module_stat.stat.checksum is defined
          and hid_module_stat.stat.checksum != '45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7' }}
 
 - name: ensure HID module is not in use


### PR DESCRIPTION
Ansible's `stat.checksum` attribute only exist under the [following conditions](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/stat_module.html#return-stat/checksum):
> path exists, user can read stats, path supports hashing and supplied checksum algorithm is available

Fixes https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/73

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/162)
<!-- Reviewable:end -->
