### PR TITLE
Verify HID module checksum exists before attempting to compare it

### DIFF
--- a/tasks/install_usb_gadget.yml
+++ b/tasks/install_usb_gadget.yml
@@ -92,6 +92,7 @@
     patch_hid_module: >-
       {{ ansible_kernel is version('5.15', '<')
          and ansible_kernel is version('5.10', '>=')
+         and hid_module_stat.stat.checksum is defined
          and hid_module_stat.stat.checksum != '45f9c885e8b0e1d2fdaf4aec2179a38ad9a1c76c71f44c997c99a865fdfe72d7' }}
 
 - name: ensure HID module is not in use


### PR DESCRIPTION
The HID module patch task can fail if the target system has just upgraded the kernel, as the path to the usb_f_hid.ko won't be correct until the following reboot. To avoid crashing the install with an 'undefined variable' error, we should first verify whether the variables we need are defined.

Fixes #164

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/165)
<!-- Reviewable:end -->
