### PR TITLE
Use interface vars in nginx upstreams.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -14,10 +14,10 @@
     nginx_upstreams:
       - name: tinypilot
         servers:
-          - "127.0.0.1:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
+          - "{{ tinypilot_interface }}:{{ tinypilot_port }} fail_timeout=1s max_fails=600"
       - name: ustreamer
         servers:
-          - "127.0.0.1:{{ ustreamer_port }} fail_timeout=1s max_fails=600"
+          - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"
     nginx_vhosts:
       - listen: "{{ tinypilot_external_port }} default_server"
         server_name: "tinypilot"


### PR DESCRIPTION
While reviewing https://github.com/tiny-pilot/tinypilot/pull/869, I noticed that we weren't actually making use of the [`tinypilot_interface`](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/d466a9f481e9b2d1ef526a88e69dd41074a018be/defaults/main.yml#L10) and [`ustreamer_interface`](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/d466a9f481e9b2d1ef526a88e69dd41074a018be/vars/main.yml#L10) variables in our nginx config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/169)
<!-- Reviewable:end -->
