### PR TITLE
Generalize H264 Docker image to work with Hobbyist or Voyager

### DIFF
--- a/janus_ustreamer_docker/start.sh
+++ b/janus_ustreamer_docker/start.sh
@@ -1,2 +1,2 @@
-/ustreamer/ustreamer -f 30 --host 127.0.0.1 -p8001 --h264-sink tinypilot::ustreamer::h264 --h264-sink-rm --h264-sink-mode 777 --format uyvy --encoder omx --persistent --dv-timings --workers 3 --drop-same-frames 30 &
+/ustreamer/ustreamer "$@" &
 /opt/janus/bin/janus -F /opt/janus/lib/janus/configs/ -P /opt/janus/lib/janus/plugins/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,16 @@
 #  tags:
 #    - ustreamer
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
 - name: disable uStreamer
   systemd:
     name: ustreamer
     daemon_reload: yes
     enabled: no
     state: stopped
+  when: 'ustreamer' in services
 
 - name: install nginx
   import_tasks: nginx.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     daemon_reload: yes
     enabled: no
     state: stopped
-  when: 'ustreamer' in services
+  when: "'ustreamer' in services"
 
 - name: install nginx
   import_tasks: nginx.yml


### PR DESCRIPTION
This PR removes the hardcoded uStreamer params from the Docker initiated [`start.sh` script](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/0328b6d85266f164941ad1426358cbd25a120641/janus_ustreamer_docker/start.sh#L1) and allows the user to specify any uStreamer params when they launch the Docker container using `docker run ...`.

I've rebuilt the `janus-ustreamer` docker image with the updated `start.sh` script and uploaded it to a public docker hub repo: https://hub.docker.com/r/jdeanwallace/janus-ustreamer

You can test the updated docker image following the instructions outlined in https://github.com/tiny-pilot/tinypilot/pull/915

### Note

I ran into issue when installing TinyPilot on a device running a fresh version of Rasbian. The `experimental/h264` branch attempts to disable uStreamer, but ansible fails when uStreamer is not yet installed. I added a workaround that [identifies all the systemd services](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/0328b6d85266f164941ad1426358cbd25a120641/tasks/main.yml#L10-L11) on the device and [only disables uStreamer if it already exists](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/0328b6d85266f164941ad1426358cbd25a120641/tasks/main.yml#L19).

Resolves #178

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/183)
<!-- Reviewable:end -->
