### PR TITLE
Remove ustreamer service from h264 docker image

### DIFF
--- a/janus_ustreamer_docker/Dockerfile
+++ b/janus_ustreamer_docker/Dockerfile
@@ -74,6 +74,5 @@ RUN git clone --depth=1 https://github.com/pikvm/ustreamer && \
 
 COPY janus.plugin.ustreamer.jcfg /opt/janus/lib/janus/configs/janus.plugin.ustreamer.jcfg
 COPY janus.transport.websockets.jcfg /opt/janus/lib/janus/configs/janus.transport.websockets.jcfg
-COPY start.sh /start.sh
 
-ENTRYPOINT ["bash", "./start.sh"]
+ENTRYPOINT ["/opt/janus/bin/janus", "-F", "/opt/janus/lib/janus/configs/", "-P", "/opt/janus/lib/janus/plugins/"]

--- a/janus_ustreamer_docker/README.md
+++ b/janus_ustreamer_docker/README.md
@@ -18,13 +18,13 @@ pushd $(mktemp -d) && \
   git clone https://github.com/tiny-pilot/ansible-role-tinypilot.git . && \
   git checkout experimental/h264 && \
   cd janus_ustreamer_docker && \
-  docker build -t janus-ustreamer .
+  docker build -t janus .
 ```
 
 **Note**: You can also make use of the pre-built Docker image by running the following command:
 
 ```bash
-docker pull jdeanwallace/janus-ustreamer:2022-02-25
+docker pull tinypilotkvm/janus:2022-03-07
 ```
 
 ## Running
@@ -38,8 +38,8 @@ docker run \
   --privileged \
   --network host \
   --volume /dev/shm:/dev/shm \
-  --name janus-ustreamer \
-  janus-ustreamer:latest
+  --name janus \
+  janus:latest
 ```
 
 It will likely [fail](https://github.com/tiny-pilot/ansible-role-tinypilot/issues/167#issuecomment-1011419160), so you have to reboot the system and then run the same command again. It's unclear why the reboot is required.

--- a/janus_ustreamer_docker/README.md
+++ b/janus_ustreamer_docker/README.md
@@ -21,26 +21,23 @@ pushd $(mktemp -d) && \
   docker build -t janus-ustreamer .
 ```
 
-**Note**: Michael created a pre-built image, but he hasn't tested it yet: `docker pull mtlynch/ustreamer-janus:2022-01-17`
-
-## Turn off uStreamer
-
-If you're running uStreamer as a service, stop the service.
+**Note**: You can also make use of the pre-built Docker image by running the following command:
 
 ```bash
-sudo service ustreamer stop
+docker pull jdeanwallace/janus-ustreamer:2022-02-25
 ```
 
 ## Running
 
-Port `8001` is where ustreamer is listening for mjpeg stream requests (nice to have as a fallback)
+uStreamer should aleady be running on the device and listening on port `8001` for mjpeg stream requests, as a fallback.
 
-Port `8002` is where janus is listening for websocket requests
+To get Janus running and listening on port `8002` for websocket requests, run the following command:
 
 ```bash
 docker run \
   --privileged \
   --network host \
+  --volume /dev/shm:/dev/shm \
   --name janus-ustreamer \
   janus-ustreamer:latest
 ```

--- a/janus_ustreamer_docker/start.sh
+++ b/janus_ustreamer_docker/start.sh
@@ -1,2 +1,1 @@
-/ustreamer/ustreamer "$@" &
 /opt/janus/bin/janus -F /opt/janus/lib/janus/configs/ -P /opt/janus/lib/janus/plugins/

--- a/janus_ustreamer_docker/start.sh
+++ b/janus_ustreamer_docker/start.sh
@@ -1,1 +1,0 @@
-/opt/janus/bin/janus -F /opt/janus/lib/janus/configs/ -P /opt/janus/lib/janus/plugins/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,8 @@
 ---
-# Disable uStreamer install, as this experimental version runs it
-# under Docker with Janus.
-
-#- name: install uStreamer
-#  import_tasks: ustreamer.yml
-#  tags:
-#    - ustreamer
-
-- name: Populate service facts
-  ansible.builtin.service_facts:
-
-- name: disable uStreamer
-  systemd:
-    name: ustreamer
-    daemon_reload: yes
-    enabled: no
-    state: stopped
-  when: "'ustreamer' in services"
+- name: install uStreamer
+  import_tasks: ustreamer.yml
+  tags:
+    - ustreamer
 
 - name: install nginx
   import_tasks: nginx.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,8 +10,7 @@ tinypilot_user: tinypilot
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
-ustreamer_repo_version: master
-ustreamer_compile_omx: yes
+ustreamer_repo_version: v4.13
 ustreamer_h264_sink: tinypilot::ustreamer::h264
 ustreamer_h264_sink_mode: 777
 ustreamer_h264_sink_rm: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,7 +10,11 @@ tinypilot_user: tinypilot
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
-ustreamer_repo_version: 'v3.26'
+ustreamer_repo_version: master
+ustreamer_compile_omx: yes
+ustreamer_h264_sink: tinypilot::ustreamer::h264
+ustreamer_h264_sink_mode: 777
+ustreamer_h264_sink_rm: yes
 
 # janus variables
 janus_ws_port: 8002


### PR DESCRIPTION
This PR depends on https://github.com/tiny-pilot/ansible-role-ustreamer/pull/54 being merged.

This PR removes uStreamer from the h264 docker image, re-enables uStreamer on the device, and makes use of the h264 memsink parameters now available in [`ansible-role-ustreamer`](https://github.com/tiny-pilot/ansible-role-ustreamer/blob/b4ac42194dfc26db52a00fe0738451a3b61bc05f/defaults/main.yml#L87-L97).

### Note
The uStreamer Janus plugin was added to uStreamer >= v4.0. Currently, I just [bumped the uStreamer version to `master`](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/15ae088820e44c8af07010320a58e1ee745202f7/vars/main.yml#L13), but we should rather pull in the latest [uStreamer code from upstream](https://github.com/pikvm/ustreamer) and specify a real version number instead.

Resolves #179

You can test the [updated H264 docker image](https://hub.docker.com/layers/jdeanwallace/janus-ustreamer/2022-02-25/images/sha256-df257898228bb2ba1bf042f210fd287167b1fc17a8bd55aed76580fd02dc5ce2?context=explore) by following the instructions in this temporary PR: https://github.com/tiny-pilot/tinypilot/pull/923

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/184)
<!-- Reviewable:end -->
