### PR TITLE
Write overview and introduction to `configfs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ ansible-galaxy install git+https://github.com/tiny-pilot/ansible-role-tinypilot.
 ansible-playbook example.yml
 ```
 
+## Documentation
+
+- [Introduction to the USB gadget driver](docs/usb-gadget-driver.md)
+
 ## License
 
 MIT

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -36,7 +36,7 @@ The `configfs` files and folders must be in line with a specific, predefined str
       - `hid.keyboard/`: USB keyboard config
       - `mass_storage.0`: USB mass storage config
     - `configs/`: This folder contains the complete and authoritative configurations for the USB gadget. There could be multiple ones, but we only use one right now, which is identified by `c.1`.
-      - `c.1/`:
+      - `c.1/`: Among others:
         - `strings/`: Device info, like the serial number or the manufacturer name.
         - `hid.mouse/`: Example of a symlink to the `functions/hid.mouse` folder. It only allows a symlink here, you can’t create the configuration in place.
 
@@ -51,6 +51,6 @@ The `configfs` virtual file system does **not** behave like a regular disk file 
 - When creating a new `functions/` sub-folder, the kernel automatically and immediately sets up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.
 - Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true if the folder isn’t empty, in which case `rmdir` would usually fail.
 - `functions/` folders can only be deleted when they are **not** referenced by a symlink from the `configs/c.1/` folder, otherwise the deletion attempt fails.
-- Symlinks have special meaning, and creating or deleting them might have side-effects. Also, `configfs` nodes cannot be symlinked from outside the virtual file system.
+- Symlinks have special meaning, and creating or deleting them might have side-effects. Also, `configfs` items cannot be symlinked from outside the virtual file system.
 - Some operations can only be carried out while the gadget is deactivated, or they only take effect after re-activating the gadget.
 - Configuration changes that are made while the gadget is active might silently fail, i.e. they could leave the entire gadget in an inconsistent or broken state, despite the command itself returning exit code `0`. Therefore, it’s important to be mindful of potential failure cases.

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -1,0 +1,62 @@
+# USB Gadget Driver and `configfs`
+
+We use `configfs` for configuring the USB gadget driver. Since `configfs` can
+feel unfamiliar to work with, here is a quick overview of how it works, and what
+some of its quirks are.
+
+See also the Linux kernel documentation:
+
+- [`configfs` overview](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt)
+- [USB gadget driver](https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt)
+
+## Introduction
+
+`configfs` is a virtual file system provided by the Linux kernel. It is mounted
+underneath `/sys/kernel/config/`. The file system does not map to any persistent
+disk, though, but the entire structure is held in memory.
+
+The basic idea behind `configfs` is to interact with kernel functionality via
+the file system APIs. So the file and directory entries in `configfs` are like a
+facade that’s wrapped around regular operating system APIs. Making changes to
+`configfs` files or folders is equivalent to making function calls (to system
+APIs), rather than merely persisting values somewhere.
+
+Examples for possible operations:
+
+```bash
+# Set up a USB mouse.
+mkdir -p functions/hid.mouse
+
+# Make mass storage behave like a CD-ROM drive.
+echo 1 > functions/mass_storage.0/lun.0/cdrom
+```
+
+## Virtual File System
+
+The `configfs` files and folders must follow a specific structure. Its file
+system does **not** behave like a regular disk file system in many ways, which
+might make it feel unnatural to work with. Some examples:
+
+- You cannot create arbitrary files or folders, but you can only create nodes
+  at predefined places.
+- When writing parameters into files, it might require the values to be in a
+  certain format. (So the parameters are essentially validated at write-time.)
+- Changes are effectuated immediately and synchronously, just as if you had
+  made calls to the respective system API directly, e.g. via C functions.
+- Sometimes, operations must be carried out in a specific order that depends
+  on internal logic rather than on conventional file system rules. E.g., when
+  writing parameters into existing files, it might only work if that’s done in a
+  specific order.
+- When creating a new folder, it might automatically and immediately set up a
+  content structure of files and sub-folders. As mentioned above, that structure
+  is fixed and can’t be changed.
+- Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true
+  if the folder isn’t empty, in which case `rmdir` would usually fail.
+- Symlinks have special meaning, and creating or deleting them might have
+  side-effects. Also, `configfs` nodes cannot be symlinked from outside the
+  virtual file system.
+- Some operations can only be carried out while the gadget is deactivated, or
+  they only take effect after re-activating the gadget. Changes that are made
+  while the gadget is active might silently fail, i.e. they could leave the
+  entire gadget in an inconsistent or broken state, despite the command
+  returning exit code `0`.

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -45,7 +45,7 @@ The `configfs` files and folders must be in line with a specific, predefined str
 The `configfs` virtual file system does **not** behave like a regular disk file system in many ways. Some examples:
 
 - You cannot create arbitrary files or folders, or rename them, but you can only create items at predefined places with predefined names.
-- When writing parameters into files, it might require the values to be in a certain format. (I.e., the parameters are essentially validated at write-time.)
+- When writing parameters into files, it might require the values to be in a certain format (i.e., the parameters are essentially validated at write-time).
 - Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions. Unlike with other file-based configurations, you don’t have to restart any service or such.
 - Sometimes, operations must be carried out in a specific order that depends on internal logic rather than on conventional file system rules. E.g., when writing parameters into existing files, it might only work if that’s done in a specific order.
 - When creating a new `functions/` sub-folder, the kernel automatically and immediately sets up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -1,8 +1,6 @@
 # USB Gadget Driver and `configfs`
 
-We use `configfs` for configuring the USB gadget driver. Since `configfs` can
-feel unfamiliar to work with, here is a quick overview of how it works, and what
-some of its quirks are.
+We use `configfs` for configuring the USB gadget driver. Since `configfs` can feel unintuitive to work with, here is a quick overview of how it works, and what some of its quirks are.
 
 See also the Linux kernel documentation:
 
@@ -11,15 +9,9 @@ See also the Linux kernel documentation:
 
 ## Introduction
 
-`configfs` is a virtual file system provided by the Linux kernel. It is mounted
-underneath `/sys/kernel/config/`. The file system does not map to any persistent
-disk, though, but the entire structure is held in memory.
+`configfs` is a virtual file system provided by the Linux kernel. It is mounted underneath `/sys/kernel/config/`. The file system does not map to any persistent disk, though, but the entire structure is held in memory.
 
-The basic idea behind `configfs` is to interact with kernel functionality via
-the file system APIs. So the file and directory entries in `configfs` are like a
-facade that’s wrapped around regular operating system APIs. Making changes to
-`configfs` files or folders is equivalent to making function calls (to system
-APIs), rather than merely persisting values somewhere.
+The basic idea behind `configfs` is to interact with kernel functionality via the file system APIs. So the file and directory entries in `configfs` are like a facade that’s wrapped around regular operating system APIs. Making changes to`configfs` files or folders is equivalent to making function calls (to system APIs), rather than merely persisting values somewhere.
 
 Examples for possible operations:
 
@@ -33,30 +25,15 @@ echo 1 > functions/mass_storage.0/lun.0/cdrom
 
 ## Virtual File System
 
-The `configfs` files and folders must follow a specific structure. Its file
-system does **not** behave like a regular disk file system in many ways, which
-might make it feel unnatural to work with. Some examples:
+The `configfs` virtual file system does **not** behave like a regular disk file system in many ways. Some examples:
 
-- You cannot create arbitrary files or folders, but you can only create nodes
-  at predefined places.
-- When writing parameters into files, it might require the values to be in a
-  certain format. (So the parameters are essentially validated at write-time.)
-- Changes are effectuated immediately and synchronously, just as if you had
-  made calls to the respective system API directly, e.g. via C functions.
-- Sometimes, operations must be carried out in a specific order that depends
-  on internal logic rather than on conventional file system rules. E.g., when
-  writing parameters into existing files, it might only work if that’s done in a
-  specific order.
-- When creating a new folder, it might automatically and immediately set up a
-  content structure of files and sub-folders. As mentioned above, that structure
-  is fixed and can’t be changed.
-- Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true
-  if the folder isn’t empty, in which case `rmdir` would usually fail.
-- Symlinks have special meaning, and creating or deleting them might have
-  side-effects. Also, `configfs` nodes cannot be symlinked from outside the
-  virtual file system.
-- Some operations can only be carried out while the gadget is deactivated, or
-  they only take effect after re-activating the gadget. Changes that are made
-  while the gadget is active might silently fail, i.e. they could leave the
-  entire gadget in an inconsistent or broken state, despite the command
-  returning exit code `0`.
+- You cannot create arbitrary files or folders, but you can only create nodes at predefined places.
+- When writing parameters into files, it might require the values to be in a certain format. (I.e., the parameters are essentially validated at write-time.)
+- Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions.
+- Sometimes, operations must be carried out in a specific order that depends on internal logic rather than on conventional file system rules. E.g., when writing parameters into existing files, it might only work if that’s done in a specific order.
+- When creating a new folder, the kernel might automatically and immediately set up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.
+- Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true if the folder isn’t empty, in which case `rmdir` would usually fail.
+- Folders can only be deleted when their configuration is not active. ?????
+- Symlinks have special meaning, and creating or deleting them might have side-effects. Also, `configfs` nodes cannot be symlinked from outside the virtual file system.
+- Some operations can only be carried out while the gadget is deactivated, or they only take effect after re-activating the gadget.
+- Configuration changes that are made while the gadget is active might silently fail, i.e. they could leave the entire gadget in an inconsistent or broken state, despite the command returning exit code `0`.

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -46,7 +46,7 @@ The `configfs` virtual file system does **not** behave like a regular disk file 
 
 - You cannot create arbitrary files or folders, or rename them, but you can only create items at predefined places with predefined names.
 - When writing parameters into files, it might require the values to be in a certain format. (I.e., the parameters are essentially validated at write-time.)
-- Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions. Unlike with other file-based configurations, you don’t have to restart any service or such. 
+- Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions. Unlike with other file-based configurations, you don’t have to restart any service or such.
 - Sometimes, operations must be carried out in a specific order that depends on internal logic rather than on conventional file system rules. E.g., when writing parameters into existing files, it might only work if that’s done in a specific order.
 - When creating a new `functions/` sub-folder, the kernel automatically and immediately sets up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.
 - Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true if the folder isn’t empty, in which case `rmdir` would usually fail.

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -12,7 +12,7 @@ See also the Linux kernel documentation:
 
 `configfs` is a virtual file system provided by the Linux kernel. It is mounted underneath `/sys/kernel/config/`. The file system does not map to a persistent disk, though, but the entire structure is held in memory.
 
-The basic idea behind `configfs` is to interact with kernel functionality via file system APIs. So the file and directory entries in `configfs` are like a facade that’s directly wrapped around regular operating system APIs. Making changes to`configfs` files or folders is equivalent to making function calls (to system APIs), rather than merely persisting values on disk.
+The basic idea behind `configfs` is to interact with kernel functionality via file system APIs. So the file and directory entries in `configfs` are like a facade that’s directly wrapped around regular operating system APIs. Making changes to `configfs` files or folders is equivalent to making function calls (to system APIs), rather than merely persisting values on disk.
 
 Examples for possible operations:
 

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -6,6 +6,7 @@ See also the Linux kernel documentation:
 
 - [General `configfs` overview](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt)
 - [USB gadget driver](https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt)
+- [Reference of available parameters and possible values](https://www.kernel.org/doc/Documentation/ABI/testing/)
 
 ## Introduction
 

--- a/docs/usb-gadget-driver.md
+++ b/docs/usb-gadget-driver.md
@@ -4,36 +4,52 @@ We use `configfs` for configuring the USB gadget driver. Since `configfs` can fe
 
 See also the Linux kernel documentation:
 
-- [`configfs` overview](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt)
+- [General `configfs` overview](https://www.kernel.org/doc/Documentation/filesystems/configfs/configfs.txt)
 - [USB gadget driver](https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt)
 
 ## Introduction
 
-`configfs` is a virtual file system provided by the Linux kernel. It is mounted underneath `/sys/kernel/config/`. The file system does not map to any persistent disk, though, but the entire structure is held in memory.
+`configfs` is a virtual file system provided by the Linux kernel. It is mounted underneath `/sys/kernel/config/`. The file system does not map to a persistent disk, though, but the entire structure is held in memory.
 
-The basic idea behind `configfs` is to interact with kernel functionality via the file system APIs. So the file and directory entries in `configfs` are like a facade that’s wrapped around regular operating system APIs. Making changes to`configfs` files or folders is equivalent to making function calls (to system APIs), rather than merely persisting values somewhere.
+The basic idea behind `configfs` is to interact with kernel functionality via file system APIs. So the file and directory entries in `configfs` are like a facade that’s directly wrapped around regular operating system APIs. Making changes to`configfs` files or folders is equivalent to making function calls (to system APIs), rather than merely persisting values on disk.
 
 Examples for possible operations:
 
 ```bash
-# Set up a USB mouse.
+# Set up config for a USB mouse.
 mkdir -p functions/hid.mouse
 
 # Make mass storage behave like a CD-ROM drive.
 echo 1 > functions/mass_storage.0/lun.0/cdrom
 ```
 
-## Virtual File System
+## Internal folder structure
+
+The `configfs` files and folders must be in line with a specific, predefined structure.
+
+- `/sys/kernel/config/usb_gadget/`: Contains a sub-folder per gadget configuration.
+  - `g1/`: We have a single gadget registered right now, which is identified by `g1`. Among other items, this folder contains:
+    - `UDC`: While the gadget is activated, this contains the name of the USB device controller (hence the acronym). If the gadget is deactivated, this file is empty. That means, the active-state of the gadget can be controlled through the value in this file.
+    - `functions/`: Contains the actual configurations for the USB interface features. Creating a sub-folder (e.g. `hid.mouse` for the USB mouse) will automatically set up the internal file structure of that new folder. These functions need to be symlinked from the `configs/c.1` folder, otherwise they won’t have any effect. Example items:
+      - `hid.mouse/`: USB mouse config
+      - `hid.keyboard/`: USB keyboard config
+      - `mass_storage.0`: USB mass storage config
+    - `configs/`: This folder contains the complete and authoritative configurations for the USB gadget. There could be multiple ones, but we only use one right now, which is identified by `c.1`.
+      - `c.1/`:
+        - `strings/`: Device info, like the serial number or the manufacturer name.
+        - `hid.mouse/`: Example of a symlink to the `functions/hid.mouse` folder. It only allows a symlink here, you can’t create the configuration in place.
+
+## Behaviour
 
 The `configfs` virtual file system does **not** behave like a regular disk file system in many ways. Some examples:
 
-- You cannot create arbitrary files or folders, but you can only create nodes at predefined places.
+- You cannot create arbitrary files or folders, or rename them, but you can only create items at predefined places with predefined names.
 - When writing parameters into files, it might require the values to be in a certain format. (I.e., the parameters are essentially validated at write-time.)
-- Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions.
+- Changes are effectuated immediately and synchronously, just as if you had made calls to the respective system API directly, e.g. via C functions. Unlike with other file-based configurations, you don’t have to restart any service or such. 
 - Sometimes, operations must be carried out in a specific order that depends on internal logic rather than on conventional file system rules. E.g., when writing parameters into existing files, it might only work if that’s done in a specific order.
-- When creating a new folder, the kernel might automatically and immediately set up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.
+- When creating a new `functions/` sub-folder, the kernel automatically and immediately sets up a content structure of files and sub-folders. As mentioned above, that structure is fixed and can’t be changed.
 - Folders can only be deleted via `rmdir`, not via `rm -rf`. That’s even true if the folder isn’t empty, in which case `rmdir` would usually fail.
-- Folders can only be deleted when their configuration is not active. ?????
+- `functions/` folders can only be deleted when they are **not** referenced by a symlink from the `configs/c.1/` folder, otherwise the deletion attempt fails.
 - Symlinks have special meaning, and creating or deleting them might have side-effects. Also, `configfs` nodes cannot be symlinked from outside the virtual file system.
 - Some operations can only be carried out while the gadget is deactivated, or they only take effect after re-activating the gadget.
-- Configuration changes that are made while the gadget is active might silently fail, i.e. they could leave the entire gadget in an inconsistent or broken state, despite the command returning exit code `0`.
+- Configuration changes that are made while the gadget is active might silently fail, i.e. they could leave the entire gadget in an inconsistent or broken state, despite the command itself returning exit code `0`. Therefore, it’s important to be mindful of potential failure cases.

--- a/files/init-usb-gadget
+++ b/files/init-usb-gadget
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Configures USB gadgets per: https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt
+# Configures USB gadgets, see: docs/usb-gadget-driver.md
 
 # Exit on first error.
 set -e

--- a/files/lib/usb-gadget.sh
+++ b/files/lib/usb-gadget.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Shared parameters and functionality for the usb gadget.
+# See: docs/usb-gadget-driver.md
+
 export readonly USB_DEVICE_DIR="g1"
 export readonly USB_GADGET_PATH="/sys/kernel/config/usb_gadget"
 export readonly USB_DEVICE_PATH="${USB_GADGET_PATH}/${USB_DEVICE_DIR}"

--- a/files/remove-usb-gadget
+++ b/files/remove-usb-gadget
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Tears down USB gadgets per: https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt
+# Tears down USB gadgets, see: docs/usb-gadget-driver.md
 
 # Exit on first error.
 set -e


### PR DESCRIPTION
When working on https://github.com/tiny-pilot/ansible-role-tinypilot-pro/pull/86, it took me a while again to wrap my head around the quirks and inner workings of `configfs`. I remember from a year ago, when working on mass storage initially, I also struggled to understand it in the beginning. Unfortunately, there is not too much introductory documentation available online.

Therefore, I thought it would be worthwhile to write up our own overview, to remind our future selves (and potentially new developers too) and get up to speed a bit quicker.

When it comes to the behaviour of configfs, I think we shouldn’t repeat the same general comments all over the place, e.g. why we use `rmdir` instead of `rm -rf` for non-empty configfs directories. This is just how configfs works in general, not something that’s specific about our particular use case. While it’s easy to forget about these details, we could create a lot of unwanted noise that way. So maybe it’s sufficient to maintain one central primer instead.

Thoughts? @mtlynch @jdeanwallace @rw4nn 

Not sure `docs/...` is the right place?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/185)
<!-- Reviewable:end -->
