### PR TITLE
Refactor USB gadget library

### DIFF
--- a/files/init-usb-gadget
+++ b/files/init-usb-gadget
@@ -127,16 +127,14 @@ echo -ne \\xC0           # END_COLLECTION
 } >> "$D"
 cp "$D" "${USB_MOUSE_FUNCTIONS_DIR}/report_desc"
 
-CONFIG_INDEX=1
-CONFIG_INDEX_DIR="${USB_CONFIGS_DIR}/c.${CONFIG_INDEX}"
-mkdir -p "$CONFIG_INDEX_DIR"
-echo 250 > "${CONFIG_INDEX_DIR}/MaxPower"
+mkdir -p "${USB_CONFIG_DIR}"
+echo 250 > "${USB_CONFIG_DIR}/MaxPower"
 
-CONFIGS_STRINGS_DIR="${CONFIG_INDEX_DIR}/${USB_STRINGS_DIR}"
-mkdir -p "$CONFIGS_STRINGS_DIR"
-echo "Config ${CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configuration"
+CONFIGS_STRINGS_DIR="${USB_CONFIG_DIR}/${USB_STRINGS_DIR}"
+mkdir -p "${CONFIGS_STRINGS_DIR}"
+echo "Config ${USB_CONFIG_INDEX}: ECM network" > "${CONFIGS_STRINGS_DIR}/configuration"
 
-ln -s "$USB_KEYBOARD_FUNCTIONS_DIR" "${CONFIG_INDEX_DIR}/"
-ln -s "$USB_MOUSE_FUNCTIONS_DIR" "${CONFIG_INDEX_DIR}/"
+ln -s "${USB_KEYBOARD_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
+ln -s "${USB_MOUSE_FUNCTIONS_DIR}" "${USB_CONFIG_DIR}/"
 
 usb_gadget_activate

--- a/files/lib/usb-gadget.sh
+++ b/files/lib/usb-gadget.sh
@@ -3,17 +3,20 @@
 export readonly USB_DEVICE_DIR="g1"
 export readonly USB_GADGET_PATH="/sys/kernel/config/usb_gadget"
 export readonly USB_DEVICE_PATH="${USB_GADGET_PATH}/${USB_DEVICE_DIR}"
-export readonly USB_FILE_CONFIG_PATH="${USB_DEVICE_PATH}/functions/mass_storage.0/lun.0/file"
-export readonly USB_CDROM_CONFIG_PATH="${USB_DEVICE_PATH}/functions/mass_storage.0/lun.0/cdrom"
 
 export readonly USB_STRINGS_DIR="strings/0x409"
 export readonly USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
 export readonly USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
-export readonly USB_MASS_STORAGE_FUNCTIONS_DIR="functions/mass_storage.0"
+export readonly USB_MASS_STORAGE_NAME="mass_storage.0"
+export readonly USB_MASS_STORAGE_FUNCTIONS_PATH="${USB_DEVICE_PATH}/functions/${USB_MASS_STORAGE_NAME}"
 
 export readonly USB_CONFIGS_DIR="configs"
 export readonly USB_ALL_CONFIGS_DIR="configs/*"
 export readonly USB_ALL_FUNCTIONS_DIR="functions/*"
+
+export readonly USB_CONFIG_INDEX=1
+export readonly USB_CONFIG_DIR="${USB_CONFIGS_DIR}/c.${USB_CONFIG_INDEX}"
+export readonly USB_CONFIG_PATH="${USB_DEVICE_PATH}/${USB_CONFIG_DIR}"
 
 function usb_gadget_activate {
   ls /sys/class/udc > "${USB_DEVICE_PATH}/UDC"
@@ -21,3 +24,8 @@ function usb_gadget_activate {
   chmod 777 /dev/hidg1
 }
 export -f usb_gadget_activate
+
+function usb_gadget_deactivate {
+  echo '' > "${USB_DEVICE_PATH}/UDC"
+}
+export -f usb_gadget_deactivate

--- a/files/lib/usb-gadget.sh
+++ b/files/lib/usb-gadget.sh
@@ -8,7 +8,7 @@ export readonly USB_STRINGS_DIR="strings/0x409"
 export readonly USB_KEYBOARD_FUNCTIONS_DIR="functions/hid.keyboard"
 export readonly USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
 export readonly USB_MASS_STORAGE_NAME="mass_storage.0"
-export readonly USB_MASS_STORAGE_FUNCTIONS_PATH="${USB_DEVICE_PATH}/functions/${USB_MASS_STORAGE_NAME}"
+export readonly USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"
 
 export readonly USB_CONFIGS_DIR="configs"
 export readonly USB_ALL_CONFIGS_DIR="configs/*"
@@ -16,7 +16,6 @@ export readonly USB_ALL_FUNCTIONS_DIR="functions/*"
 
 export readonly USB_CONFIG_INDEX=1
 export readonly USB_CONFIG_DIR="${USB_CONFIGS_DIR}/c.${USB_CONFIG_INDEX}"
-export readonly USB_CONFIG_PATH="${USB_DEVICE_PATH}/${USB_CONFIG_DIR}"
 
 function usb_gadget_activate {
   ls /sys/class/udc > "${USB_DEVICE_PATH}/UDC"


### PR DESCRIPTION
These are the changes pulled out from https://github.com/tiny-pilot/ansible-role-tinypilot-pro/pull/86/files.

- No behavioural changes.
- The library file is apparently supposed to be the same in both repos (which I think makes sense). So I kept it that way, even if we don’t actually need `usb_gadget_deactivate` here.
- For all shell variables that I touched, [I added `{`…`}`](https://google.github.io/styleguide/shellguide.html#variable-expansion).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/186)
<!-- Reviewable:end -->
