### PR TITLE
Simplify and re-order variables for USB gadget

### DIFF
--- a/files/lib/usb-gadget.sh
+++ b/files/lib/usb-gadget.sh
@@ -10,12 +10,10 @@ export readonly USB_MOUSE_FUNCTIONS_DIR="functions/hid.mouse"
 export readonly USB_MASS_STORAGE_NAME="mass_storage.0"
 export readonly USB_MASS_STORAGE_FUNCTIONS_DIR="functions/${USB_MASS_STORAGE_NAME}"
 
-export readonly USB_CONFIGS_DIR="configs"
+export readonly USB_CONFIG_INDEX=1
+export readonly USB_CONFIG_DIR="configs/c.${USB_CONFIG_INDEX}"
 export readonly USB_ALL_CONFIGS_DIR="configs/*"
 export readonly USB_ALL_FUNCTIONS_DIR="functions/*"
-
-export readonly USB_CONFIG_INDEX=1
-export readonly USB_CONFIG_DIR="${USB_CONFIGS_DIR}/c.${USB_CONFIG_INDEX}"
 
 function usb_gadget_activate {
   ls /sys/class/udc > "${USB_DEVICE_PATH}/UDC"


### PR DESCRIPTION
Tiny code-cleanup in `lib/usb-gadget.sh`, without any behavioural effect:

We ended up with two variables that have almost the same name, `USB_CONFIGS_DIR` and `USB_CONFIG_DIR`. Apart from that causing confusion, we don’t actually need to export the former, since [the only usage is in the file itself](https://github.com/tiny-pilot/ansible-role-tinypilot/search?q=USB_CONFIGS_DIR). But for simplicity, we can as well just remove the variable altogether and repeat the value. We do the same already for the `functions/` substring in other variables, which I find readable and straightforward.

I’ve also grouped and reordered the variables, because it felt more sensible that way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/187)
<!-- Reviewable:end -->
