### PR TITLE
Format help output in a consistent way

### DIFF
--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -7,9 +7,8 @@ print_help() {
     cat << EOF
 Usage: ${0##*/} [-hq]
 Collect debug logs.
-
-    -h Display this help and exit.
-    -q Run in silent mode without prompting user for inputs.
+  -h Display this help and exit.
+  -q Run in silent mode without prompting user for inputs.
 EOF
 }
 

--- a/files/init-usb-gadget
+++ b/files/init-usb-gadget
@@ -15,6 +15,27 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # shellcheck source=lib/usb-gadget.sh
 source "${SCRIPT_DIR}/lib/usb-gadget.sh"
 
+print_help() {
+  cat << EOF
+Usage: ${0##*/} [-h]
+Init USB gadget.
+  -h Display this help and exit.
+EOF
+}
+
+# Parse command-line arguments.
+while getopts "h" opt; do
+  case "${opt}" in
+    h)
+      print_help
+      exit
+      ;;
+    *)
+      print_help >&2
+      exit 1
+  esac
+done
+
 modprobe libcomposite
 
 # Adapted from https://github.com/girst/hardpass-sendHID/blob/master/README.md

--- a/files/update-video-settings
+++ b/files/update-video-settings
@@ -12,9 +12,8 @@ print_help() {
     cat << EOF
 Usage: ${0##*/} [-hq]
 Update uStreamer video settings.
-
-    -h Display this help and exit.
-    -q Run in quiet mode.
+  -h Display this help and exit.
+  -q Run in quiet mode.
 EOF
 }
 


### PR DESCRIPTION
The help output of the scripts is not formatted in a consistent way currently. This PR, along with [its counterpart in Pro](https://github.com/tiny-pilot/ansible-role-tinypilot-pro/pull/93), establishes the following convention:

- Usage on the first line
- Description on the next line, worded in 3rd person; not indented
- No blank subsequent line (just to make it more concise visually)
- Arguments indented with 2 spaces

I also noticed that the help feature was missing completely in `init-usb-gadget`, so I back-ported it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/188)
<!-- Reviewable:end -->
