### PR TITLE
Install Janus Gateway and uStreamer Janus plugin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
 tinypilot_pip_args: ""
 tinypilot_app_settings_file: "{{ tinypilot_dir }}/app_settings.cfg"
+tinypilot_install_janus: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,6 @@ tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
 tinypilot_pip_args: ""
 tinypilot_app_settings_file: "{{ tinypilot_dir }}/app_settings.cfg"
+# (Experimental): Install the Janus WebRTC server to enable uStreamer to stream
+# video over H264 instead of MJPEG.
 tinypilot_install_janus: no

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 - src: https://github.com/tiny-pilot/ansible-role-ustreamer
 - src: https://github.com/tiny-pilot/ansible-role-nginx
+- src: https://github.com/tiny-pilot/ansible-role-janus-gateway

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -1,0 +1,4 @@
+---
+- name: import Janus Gateway role
+  import_role:
+    name: ansible-role-janus-gateway

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: install Janus Gateway
+  import_tasks: janus.yml
+  tags:
+    - janus
+  when: tinypilot_install_janus
+
 - name: install uStreamer
   import_tasks: ustreamer.yml
   tags:

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -18,6 +18,9 @@
       - name: ustreamer
         servers:
           - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"
+      - name: janus-ws
+        servers:
+          - "{{ janus_ws_interface }}:{{ janus_ws_port }} fail_timeout=1s max_fails=600"
     nginx_vhosts:
       - listen: "{{ tinypilot_external_port }} default_server"
         server_name: "tinypilot"
@@ -53,6 +56,17 @@
           }
           location /snapshot {
             proxy_pass http://ustreamer;
+          }
+          location /janus/ws {
+            proxy_pass http://janus-ws;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Scheme $scheme;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           }
           location / {
             proxy_pass http://tinypilot;

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,4 +1,18 @@
 ---
+# We're unable to build the uStreamer Janus plugin because an include statement
+# references the wrong file path.
+# TODO: Create a PR to patch this bug in the janus-gateway repo.
+- name: patch Janus plugin.h file to successfully include refcount.h file
+  command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "{{ janus_install_dir }}/include/janus/plugins/plugin.h"
+  when: tinypilot_install_janus
+
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
+
+- name: install uStreamer Janus plugin
+  copy:
+    remote_src: yes
+    src: "{{ ustreamer_dir }}/janus/libjanus_ustreamer.so"
+    dest: "{{ janus_install_dir }}/lib/janus/plugins/"
+  when: tinypilot_install_janus and ustreamer_compile_janus_plugin

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -4,15 +4,27 @@
 # TODO: Create a PR to patch this bug in the janus-gateway repo.
 - name: patch Janus plugin.h file to successfully include refcount.h file
   command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "{{ janus_install_dir }}/include/janus/plugins/plugin.h"
-  when: tinypilot_install_janus
+  when: tinypilot_install_janus and ustreamer_compile_janus_plugin
 
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
+
+- name: create uStreamer Janus plugin config
+  template:
+    src: janus.plugin.ustreamer.jcfg.j2
+    dest: "{{ janus_conf_dir }}/janus.plugin.ustreamer.jcfg"
+  when: >-
+    tinypilot_install_janus
+    and ustreamer_compile_janus_plugin
+    and ustreamer_h264_sink != None
 
 - name: install uStreamer Janus plugin
   copy:
     remote_src: yes
     src: "{{ ustreamer_dir }}/janus/libjanus_ustreamer.so"
     dest: "{{ janus_install_dir }}/lib/janus/plugins/"
-  when: tinypilot_install_janus and ustreamer_compile_janus_plugin
+  when: >-
+    tinypilot_install_janus
+    and ustreamer_compile_janus_plugin
+    and ustreamer_h264_sink != None

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,7 +1,7 @@
 ---
 # We're unable to build the uStreamer Janus plugin because an include statement
 # references the wrong file path.
-# TODO: Create a PR to patch this bug in the janus-gateway repo.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192
 - name: patch Janus plugin.h file to successfully include refcount.h file
   command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "{{ janus_install_dir }}/include/janus/plugins/plugin.h"
   when: tinypilot_install_janus and ustreamer_compile_janus_plugin

--- a/templates/janus.plugin.ustreamer.jcfg.j2
+++ b/templates/janus.plugin.ustreamer.jcfg.j2
@@ -1,0 +1,3 @@
+memsink: {
+    object = "{{ ustreamer_h264_sink }}"
+}

--- a/templates/tinypilot-app-settings.cfg.j2
+++ b/templates/tinypilot-app-settings.cfg.j2
@@ -3,6 +3,7 @@
 
 KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
 MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
-{% if tinypilot_install_janus and ustreamer_compile_janus_plugin and ustreamer_h264_sink != None -%}
+{% if (tinypilot_install_janus and ustreamer_compile_janus_plugin and
+           ustreamer_h264_sink != None) -%}
 USE_WEBRTC_REMOTE_SCREEN = True
 {% endif -%}

--- a/templates/tinypilot-app-settings.cfg.j2
+++ b/templates/tinypilot-app-settings.cfg.j2
@@ -3,3 +3,6 @@
 
 KEYBOARD_PATH = '{{ tinypilot_keyboard_interface }}'
 MOUSE_PATH = '{{ tinypilot_mouse_interface }}'
+{% if tinypilot_install_janus and ustreamer_compile_janus_plugin and ustreamer_h264_sink != None -%}
+USE_WEBRTC_REMOTE_SCREEN = True
+{% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,4 +10,4 @@ tinypilot_user: tinypilot
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
-ustreamer_repo_version: 'v3.26'
+ustreamer_repo_version: v4.13

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,3 +11,5 @@ ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 ustreamer_repo_version: v4.13
+
+janus_version: v1.0.0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,3 +13,5 @@ ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 ustreamer_repo_version: v4.13
 
 janus_version: v1.0.0
+janus_ws_interface: '127.0.0.1'
+janus_ws_port: 8188

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,5 +13,8 @@ ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 ustreamer_repo_version: v4.13
 
 janus_version: v1.0.0
+
+# These variables are only used within this role and don't affect the Janus
+# role.
 janus_ws_interface: '127.0.0.1'
 janus_ws_port: 8188


### PR DESCRIPTION
This PR allows us to install the Janus Gateway using the [`tinypilot_install_janus` variable (off by default)](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/defaults/main.yml#L19).

### Changes
1. Adds `ansible-role-janus-gateway` as a dependency ([link](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/requirements.yml#L4)).
1. Installs Janus Gateway ([link](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/tasks/main.yml#L2-L6)).
1. Patches Janus header file to allow us to compile the uStreamer Janus plugin ([link](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/tasks/ustreamer.yml#L2-L7)).
1. Create uStreamer Janus plugin config file ([link](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/templates/janus.plugin.ustreamer.jcfg.j2)).
1. Installs uStreamer Janus plugin ([link](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/tasks/ustreamer.yml#L22-L30)).
1. Upgrades uStreamer to versions `v4.13` ([link](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/ec2a68e7c95195e41f4bda51e402ebeefff1264f/vars/main.yml#L13)).
1. [Adds Janus nginx config.](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/191/commits/175b37c875e0e67ea7d1a7a76890a8b8ab846cc8)
1. [Conditionally enables WebRTC on the frontend.](https://github.com/tiny-pilot/ansible-role-tinypilot/pull/191/commits/1a4767f44bf3dab0bd594bf7a9784c04ba07855d)

Resolves https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/191)
<!-- Reviewable:end -->
