### PR TITLE
Update Janus WebSocket address.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -20,7 +20,7 @@
           - "{{ ustreamer_interface }}:{{ ustreamer_port }} fail_timeout=1s max_fails=600"
       - name: janus-ws
         servers:
-          - "{{ janus_ws_interface }}:{{ janus_ws_port }} fail_timeout=1s max_fails=600"
+          - "{{ janus_ws_ip }}:{{ janus_ws_port }} fail_timeout=1s max_fails=600"
     nginx_vhosts:
       - listen: "{{ tinypilot_external_port }} default_server"
         server_name: "tinypilot"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,8 +13,5 @@ ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 ustreamer_repo_version: v4.13
 
 janus_version: v1.0.0
-
-# These variables are only used within this role and don't affect the Janus
-# role.
-janus_ws_interface: '127.0.0.1'
-janus_ws_port: 8188
+janus_ws_ip: '127.0.0.1'
+janus_ws_port: 8002


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/101

This PR makes use of the [newly defined `janus_ws_ip` & `janus_ws_port` variables](https://github.com/tiny-pilot/ansible-role-janus-gateway/pull/8).

I've also set the Janus WebSocket port to `8002` to align with our current port numbering system, so that
* TinyPilot Flask runs on port `8000`
* uStreamer runs on port `8001`
* Janus WS runs on port `8002`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/196)
<!-- Reviewable:end -->
