### PR TITLE
Change directory owner before syncing git

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,11 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    hosts:
+      all:
+        vars:
+          ansible_user: root
 verifier:
   name: ansible
 scenario:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,8 +105,9 @@
   file:
     path: "{{ tinypilot_dir }}"
     state: directory
-    owner: "{{ tinypilot_user }}"
-    group: "{{ tinypilot_group }}"
+    owner: root
+    group: root
+    recurse: yes
 
 - name: get TinyPilot repo
   git:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,8 +105,8 @@
   file:
     path: "{{ tinypilot_dir }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     recurse: yes
   tags:
     # This fails the idempotency test because it must run on every provision
@@ -115,6 +115,9 @@
     - molecule-idempotence-notest
 
 - name: get TinyPilot repo
+  # Don't escalate privileges because only the directory owner can use git.
+  # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
+  become: no
   git:
     repo: "{{ tinypilot_repo }}"
     dest: "{{ tinypilot_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,6 +108,11 @@
     owner: root
     group: root
     recurse: yes
+  tags:
+    # This fails the idempotency test because it is run on every provision to
+    # allow git to sync.
+    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
+    - molecule-idempotence-notest
 
 - name: get TinyPilot repo
   git:
@@ -154,7 +159,6 @@
     owner: "{{ tinypilot_user }}"
     group: "{{ tinypilot_group }}"
     recurse: yes
-  # TODO: Figure out why this fails idempotency otherwise.
   tags:
     - molecule-idempotence-notest
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,8 +109,8 @@
     group: root
     recurse: yes
   tags:
-    # This fails the idempotency test because it is run on every provision to
-    # allow git to sync.
+    # This fails the idempotency test because it must run on every provision
+    # to set the correct directory ownership that allows git to sync.
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
 


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/tinypilot/issues/963

Depends on https://github.com/tiny-pilot/ansible-role-ustreamer/pull/59

Just echoing the description of above related PR:
> This is needed to allow git to sync after the announced [git security fix](https://github.blog/2022-04-12-git-security-vulnerability-announced/).
> 
> > By default, Git will refuse to even parse a Git config of a repository owned by someone else
> 
> Alternatively, we could bypass this new git behaviour by marking the git repo directory as a [`safe.directory`](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory), but that would defeat the purpose of the security fix especially seeing as we can't assume the device is a single-user machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/197)
<!-- Reviewable:end -->
