### PR TITLE
Fix `check-bash` script to consider all shebang variants

### DIFF
--- a/files/update
+++ b/files/update
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Echo commands to stdout.
 set -x

--- a/tests/check-bash
+++ b/tests/check-bash
@@ -12,11 +12,11 @@ BASH_SCRIPTS=()
 
 while read -r filepath; do
   if head -n 1 "${filepath}" | grep --quiet \
-    --regexp "#!/bin/bash" \
-    --regexp "#!/usr/bin/env bash" \
-    --regexp "#!/usr/sh" \
-    --regexp "#!/usr/bin/env sh" \
     ; then BASH_SCRIPTS+=("${filepath}")
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
   fi
 done < <(git ls-files)
 

--- a/tests/check-bash
+++ b/tests/check-bash
@@ -12,11 +12,12 @@ BASH_SCRIPTS=()
 
 while read -r filepath; do
   if head -n 1 "${filepath}" | grep --quiet \
-    ; then BASH_SCRIPTS+=("${filepath}")
     --regexp '#!/bin/bash' \
     --regexp '#!/usr/bin/env bash' \
     --regexp '#!/usr/sh' \
     --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
   fi
 done < <(git ls-files)
 

--- a/tests/check-bash
+++ b/tests/check-bash
@@ -10,14 +10,16 @@ set -u
 
 BASH_SCRIPTS=()
 
-while read -r line; do
-  BASH_SCRIPTS+=("${line}")
-done < <(find . \
-  -not -path './\.*' \
-  -not -path './venv/*' \
-  -not -path './node_modules/*' \
-  -type f \
-  -exec bash -c 'head -n 1 $1 | grep --quiet "#!/bin/bash"' _ {} \; \
-  -print)
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp "#!/bin/bash" \
+    --regexp "#!/usr/bin/env bash" \
+    --regexp "#!/usr/sh" \
+    --regexp "#!/usr/bin/env sh" \
+    ; then BASH_SCRIPTS+=("${filepath}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
 
 shellcheck "${BASH_SCRIPTS[@]}"


### PR DESCRIPTION
Fix for https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/84, that resolves the issue in this repository here.

When merging this PR into Pro later, [we need to fix one shellscript issue in the `update` script](https://github.com/tiny-pilot/ansible-role-tinypilot-pro/compare/fix-check-bash?expand=1). That one had slipped through before, because the [`update` script uses a different shebang](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/94e97fffbda088c03b0ffe0f60e9c12471d4ddc8/files/update#L1), which the old `check-bash` script didn’t consider.

Once we are happy with the `check-bash` script here, I’ll copy it over to all our other repos ([per discussion here](https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/84#issuecomment-1114712588)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/198)
<!-- Reviewable:end -->
