### PR TITLE
Install pre-built Janus Debian package

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,3 +20,8 @@
   service:
     name: usb-gadget
     state: started
+
+- name: restart janus service
+  service:
+    name: janus
+    state: restarted

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,3 @@
 ---
 - src: https://github.com/tiny-pilot/ansible-role-ustreamer
 - src: https://github.com/tiny-pilot/ansible-role-nginx
-- src: https://github.com/tiny-pilot/ansible-role-janus-gateway

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -2,7 +2,3 @@
 - name: install Janus Debian package
   apt:
     deb: "{{ janus_deb_file }}"
-    # We need to force the installation of Janus when the target device has
-    # conflicting dependencies. This does not install Janus on every provision.
-    # https://github.com/tiny-pilot/janus-debian/blob/1.0.1/Dockerfile#L172
-    force: yes

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -2,3 +2,7 @@
 - name: install Janus Debian package
   apt:
     deb: "{{ janus_deb_file }}"
+    # We need to force the installation of Janus when the target device has
+    # conflicting dependencies. This does not install Janus on every provision.
+    # https://github.com/tiny-pilot/janus-debian/blob/1.0.1/Dockerfile#L172
+    force: yes

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -1,4 +1,4 @@
 ---
-- name: import Janus Gateway role
-  import_role:
-    name: ansible-role-janus-gateway
+- name: install Janus Debian package
+  apt:
+    deb: "{{ janus_deb_file }}"

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,11 +1,4 @@
 ---
-# We're unable to build the uStreamer Janus plugin because an include statement
-# references the wrong file path.
-# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192
-- name: patch Janus plugin.h file to successfully include refcount.h file
-  command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "{{ janus_install_dir }}/include/janus/plugins/plugin.h"
-  when: tinypilot_install_janus and ustreamer_compile_janus_plugin
-
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
@@ -13,7 +6,9 @@
 - name: create uStreamer Janus plugin config
   template:
     src: janus.plugin.ustreamer.jcfg.j2
-    dest: "{{ janus_conf_dir }}/janus.plugin.ustreamer.jcfg"
+    dest: "{{ janus_install_dir }}/etc/janus/janus.plugin.ustreamer.jcfg"
+  notify:
+    - restart janus service
   when: >-
     tinypilot_install_janus
     and ustreamer_compile_janus_plugin
@@ -24,6 +19,8 @@
     remote_src: yes
     src: "{{ ustreamer_dir }}/janus/libjanus_ustreamer.so"
     dest: "{{ janus_install_dir }}/lib/janus/plugins/"
+  notify:
+    - restart janus service
   when: >-
     tinypilot_install_janus
     and ustreamer_compile_janus_plugin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,9 @@ ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
 ustreamer_repo_version: v4.13
 
-janus_version: v1.0.0
+janus_deb_file: https://github.com/tiny-pilot/janus-debian/releases/download/1.0.1/janus_1.0.1-20220519_armhf.deb
+# These variables are only used within this role and don't affect the Janus
+# installation config.
+janus_install_dir: /opt/janus
 janus_ws_ip: '127.0.0.1'
 janus_ws_port: 8002


### PR DESCRIPTION
Resolves #199

This PR removes the dependency on [ansible-role-janus-gateway](https://github.com/tiny-pilot/ansible-role-janus-gateway) (which compiles Janus from source) and instead installs our [pre-built Janus Debian package](https://github.com/tiny-pilot/janus-debian/releases/tag/1.0.1).

I've tested the following upgrade paths:
1. TinyPilot, without Janus -> TinyPilot with Janus (pre-built)
2. TinyPilot with Janus (compiled from source) -> TinyPilot with Janus (pre-built)

With regards to situation 2., the pre-built Janus package needs to install [conflicting dependencies](https://github.com/tiny-pilot/janus-debian/blob/1.0.1/Dockerfile#L172) (that is shipped with the Debian package). Seeing as these dependencies are already installed, we need to [force the Janus installation](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/1ace7f946858c25cabdfbb4f819685613751c8d5/tasks/janus.yml#L5-L8).  The [`dpkg` manual](https://man7.org/linux/man-pages/man1/dpkg.1.html) considers this dangerous, but seeing as we created this conflict to begin with, I think it should be okay 😬 
> **[force-]conflicts**: Install, even if it conflicts with another
              package. This is dangerous, for it will usually cause
              overwriting of some files.  This affects the Conflicts
              field.

Also related to situation 2., this PR doesn't attempt to remove any old files/config from the target device that has been left there from the previous Janus installation. Regardless of that, WebRTC streaming seems to work fine after the upgrade.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/200)
<!-- Reviewable:end -->
