### PR TITLE
Add an option for installing TinyPilot from a Debian package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
+# Specifies the path to a Debian package that installs TinyPilot. If unset, the
+# role installs TinyPilot from source using the tinypilot_repo variable instead.
+tinypilot_debian_package_path: null
 tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
 tinypilot_repo_branch: master
 # Port on which TinyPilot frontend listens (accessible from other hosts on the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,9 @@
 tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged
-# Specifies the path to a Debian package that installs TinyPilot. If unset, the
-# role installs TinyPilot from source using the tinypilot_repo variable instead.
+# Specifies the filesystem path or URL of a Debian package that installs
+# TinyPilot. If unset, the role installs TinyPilot from source using the
+# tinypilot_repo variable instead.
 tinypilot_debian_package_path: null
 tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
 tinypilot_repo_branch: master

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
   apt:
     name: "{{ tinypilot_packages }}"
     state: present
-  when: tinypilot_debian_package_path is null
+  when: tinypilot_debian_package_path is None
 
 - name: create tinypilot group
   group:
@@ -105,7 +105,7 @@
 - name: install TinyPilot Debian package
   apt:
     deb: "{{ tinypilot_debian_package_path }}"
-  when: tinypilot_debian_package_path is not null
+  when: tinypilot_debian_package_path
 
 - name: create TinyPilot folder
   file:
@@ -114,7 +114,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     recurse: yes
-  when: tinypilot_debian_package_path is null
+  when: tinypilot_debian_package_path is None
   tags:
     # This fails the idempotency test because it must run on every provision
     # to set the correct directory ownership that allows git to sync.
@@ -130,7 +130,7 @@
     dest: "{{ tinypilot_dir }}"
     version: "{{ tinypilot_repo_branch }}"
     accept_hostkey: yes
-  when: tinypilot_debian_package_path is null
+  when: tinypilot_debian_package_path is None
   notify:
     - restart TinyPilot service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
   apt:
     name: "{{ tinypilot_packages }}"
     state: present
-  when: tinypilot_debian_package_path is none
+  when: tinypilot_debian_package_path == None
 
 - name: create tinypilot group
   group:
@@ -105,7 +105,7 @@
 - name: install TinyPilot Debian package
   apt:
     deb: "{{ tinypilot_debian_package_path }}"
-  when: tinypilot_debian_package_path is not none
+  when: tinypilot_debian_package_path != None
 
 - name: create TinyPilot folder
   file:
@@ -114,7 +114,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     recurse: yes
-  when: tinypilot_debian_package_path is none
+  when: tinypilot_debian_package_path == None
   tags:
     # This fails the idempotency test because it must run on every provision
     # to set the correct directory ownership that allows git to sync.
@@ -130,7 +130,7 @@
     dest: "{{ tinypilot_dir }}"
     version: "{{ tinypilot_repo_branch }}"
     accept_hostkey: yes
-  when: tinypilot_debian_package_path is none
+  when: tinypilot_debian_package_path == None
   notify:
     - restart TinyPilot service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
   apt:
     name: "{{ tinypilot_packages }}"
     state: present
-  when: tinypilot_debian_package_path is None
+  when: tinypilot_debian_package_path is none
 
 - name: create tinypilot group
   group:
@@ -105,7 +105,7 @@
 - name: install TinyPilot Debian package
   apt:
     deb: "{{ tinypilot_debian_package_path }}"
-  when: tinypilot_debian_package_path
+  when: tinypilot_debian_package_path is not none
 
 - name: create TinyPilot folder
   file:
@@ -114,7 +114,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     recurse: yes
-  when: tinypilot_debian_package_path is None
+  when: tinypilot_debian_package_path is none
   tags:
     # This fails the idempotency test because it must run on every provision
     # to set the correct directory ownership that allows git to sync.
@@ -130,7 +130,7 @@
     dest: "{{ tinypilot_dir }}"
     version: "{{ tinypilot_repo_branch }}"
     accept_hostkey: yes
-  when: tinypilot_debian_package_path is None
+  when: tinypilot_debian_package_path is none
   notify:
     - restart TinyPilot service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,6 +101,11 @@
     regexp: "^{{ tinypilot_user }}"
     validate: sudo /usr/sbin/visudo -cf %s
 
+- name: install TinyPilot Debian package
+  apt:
+    deb: "{{ tinypilot_debian_package_path }}"
+  when: tinypilot_debian_package_path is not null
+
 - name: create TinyPilot folder
   file:
     path: "{{ tinypilot_dir }}"
@@ -108,6 +113,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     recurse: yes
+  when: tinypilot_debian_package_path is null
   tags:
     # This fails the idempotency test because it must run on every provision
     # to set the correct directory ownership that allows git to sync.
@@ -123,6 +129,7 @@
     dest: "{{ tinypilot_dir }}"
     version: "{{ tinypilot_repo_branch }}"
     accept_hostkey: yes
+  when: tinypilot_debian_package_path is null
   notify:
     - restart TinyPilot service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,6 +55,7 @@
   apt:
     name: "{{ tinypilot_packages }}"
     state: present
+  when: tinypilot_debian_package_path is null
 
 - name: create tinypilot group
   group:


### PR DESCRIPTION
This adds an new variable `tinypilot_debian_package_path` that allows the user to install TinyPilot via a Debian package instead of from git.

Fixes #201

---

How I tested the role:

First, manually install `python3-venv` on a fresh Raspberry Pi OS install (`python3-venv` is not yet declared as a dependency in the prototype .deb).

Then, run this playbook from a machine with Ansible:

```yaml
---
- hosts: raspberrypi
  become: True
  become_user: root
  become_method: sudo
  roles:
    - role: ansible-role-tinypilot
      vars:
        tinypilot_debian_package_path: "https://p.tinypilotkvm.com/!TzCpZrSrjS/tinypilot-pro-2.4.1-1-armhf.deb"
```

We don't have a TinyPilot Community .deb package yet, so the above installs TinyPilot Pro on a TinyPilot Community system. The web app doesn't totally work because it's expecting HTTPS, but it places the files correctly, so it gives me confidence that it will work once we have the Community .deb file.



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/202)
<!-- Reviewable:end -->
