### PR TITLE
Update update script to use new get-tinypilot.sh script

### DIFF
--- a/files/update
+++ b/files/update
@@ -12,5 +12,5 @@ set -e
 curl \
   --silent \
   --show-error \
-  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/quick-install | \
+  https://raw.githubusercontent.com/tiny-pilot/tinypilot/master/get-tinypilot.sh | \
     bash -

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
-# TinyPilot's quick-install script (which it uses for installation and updates)
-# relies on the tinypilot user being named "tinypilot" so changing this value
-# will break updates.
+# TinyPilot's get-tinypilot.sh script (which it uses for installation and
+# updates) relies on the tinypilot user being named "tinypilot" so changing this
+# value will break updates.
 tinypilot_user: tinypilot
 
 # uStreamer variables are placed here, instead of in `defaults/main.yml`,


### PR DESCRIPTION
This is gated on merging the tinypilot update-overhaul branch into master

Related: https://github.com/tiny-pilot/tinypilot/pull/1038

Fixes #204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/205)
<!-- Reviewable:end -->
