### PR TITLE
Change tinypilot_app_settings_file to /home/tinypilot/app_settings.cfg

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ tinypilot_keyboard_interface: /dev/hidg0
 tinypilot_mouse_interface: /dev/hidg1
 tinypilot_enable_debug_logging: no
 tinypilot_pip_args: ""
-tinypilot_app_settings_file: "{{ tinypilot_dir }}/app_settings.cfg"
+tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"
 # (Experimental): Install the Janus WebRTC server to enable uStreamer to stream
 # video over H264 instead of MJPEG.
 tinypilot_install_janus: no


### PR DESCRIPTION
`app_settings.cfg` contains user-configurable data, so we should be storing it in `/home/tinypilot` rather than its current location in `/opt/tinypilot`, which is purely for code.

Tested successfully on a bare Raspbian system:

```bash
$ cat /home/tinypilot/app_settings.cfg 
# This configuration file is an actual Python file. Only variables in uppercase
# are recognized as config keys.

KEYBOARD_PATH = '/dev/hidg0'
MOUSE_PATH = '/dev/hidg1'
```

Fixes #207

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-tinypilot/208)
<!-- Reviewable:end -->
