### PR TITLE
Add role dependencies.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
-  - role: ansible-role-ustreamer
-  - role: ansible-role-nginx
+  - src: https://github.com/tiny-pilot/ansible-role-ustreamer
+  - src: https://github.com/tiny-pilot/ansible-role-nginx
 
 galaxy_info:
   role_name: tinypilot

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,8 @@
 ---
+dependencies:
+  - role: ansible-role-ustreamer
+  - role: ansible-role-nginx
+
 galaxy_info:
   role_name: tinypilot
   author: Michael Lynch


### PR DESCRIPTION
Related to https://github.com/tiny-pilot/tinypilot/issues/1082

When installing this Ansible role via `ansible-galaxy` it will now automatically install its role dependencies.

Note:
1. I initially thought `ansible-galaxy` would just download the roles listed in our `requirements.yml` file, but it doesn't do that. `ansible-galaxy` requires this extra `dependencies` list inside the `meta/main.yml` file which, funny enough, takes the exact list structure seen in the `requirements.yml` file. Bizarre!
    
    So if `ansible-role-tinypilot` is installed via `ansible-galaxy` it will look at the `dependencies` list and download them. However, in dev when we already have `ansible-role-tinypilot`, but not not the dependencies, we need to install dependencies via `ansible-galaxy install -r requirements.yml`.
    
    Sucks that we need to maintain the exact same list in 2 places.
1. This change shouldn't effect [`quick-install` because we never installed `ansible-role-tinypilot` via `ansible-galaxy`, only via `git`](https://github.com/tiny-pilot/tinypilot/blob/1a72ab42d27141fce9aa241126b6bad8029ee1f4/quick-install#L175-L176), so these galaxy dependencies won't take affect.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/212"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>