### PR TITLE
Fix TinyPilot version check in `collect-debug-logs` script.

### DIFF
--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -66,14 +66,14 @@ print_info "Writing diagnostic logs to $LOG_FILE"
 echo "Software versions" >> "${LOG_FILE}"
 
 print_info "Checking TinyPilot version..."
-pushd /opt/tinypilot > /dev/null
+pushd /opt/tinypilot > /dev/null || exit
 if [[ -f VERSION ]]; then
   TINYPILOT_VERSION="$(cat VERSION)"
 else
   TINYPILOT_VERSION="$(git describe --tags --always) $(git rev-parse --short HEAD)"
 fi
 readonly TINYPILOT_VERSION
-popd > /dev/null
+popd > /dev/null || exit
 printf 'TinyPilot version: %s\n' "${TINYPILOT_VERSION}" >> "${LOG_FILE}"
 
 print_info "Checking uStreamer version..."

--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -66,8 +66,15 @@ print_info "Writing diagnostic logs to $LOG_FILE"
 echo "Software versions" >> "${LOG_FILE}"
 
 print_info "Checking TinyPilot version..."
-cd /opt/tinypilot && \
-  printf "TinyPilot version: %s %s\n" "$(git describe --tags --always)" "$(git rev-parse --short HEAD)" >> "${LOG_FILE}"
+pushd /opt/tinypilot > /dev/null
+if [[ -f VERSION ]]; then
+  TINYPILOT_VERSION="$(cat VERSION)"
+else
+  TINYPILOT_VERSION="$(git describe --tags --always) $(git rev-parse --short HEAD)"
+fi
+readonly TINYPILOT_VERSION
+popd > /dev/null
+printf 'TinyPilot version: %s\n' "${TINYPILOT_VERSION}" >> "${LOG_FILE}"
 
 print_info "Checking uStreamer version..."
 cd /opt/ustreamer && \


### PR DESCRIPTION
While testing the [update-overhaul](https://github.com/tiny-pilot/tinypilot/issues/1027), I noticed that the TinyPilot version was missing in the debug logs:

<img width="877" alt="Screen Shot 2022-08-18 at 15 49 51" src="https://user-images.githubusercontent.com/6730025/185412060-af7f66e4-ba8e-499e-9b8f-96451373540f.png">

This PR reads the TinyPilot version from the `VERSION` file (if it exists).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/217"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>