### PR TITLE
Deprecate the `tinypilot_repo` variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,11 @@ Available variables are listed below, along with default values (see [defaults/m
 ```yaml
 tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
+tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
+tinypilot_repo_branch: master
 tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
-```
-
-Mandatory variables are listed below:
-
-```yaml
-# Specify the filesystem path or URL of a Debian package that installs
-# TinyPilot.
-tinypilot_debian_package_path: tinypilot-00000000000000-1-armhf.deb
 ```
 
 ## Dependencies
@@ -43,11 +37,8 @@ tinypilot_debian_package_path: tinypilot-00000000000000-1-armhf.deb
 ### Running Example Playbook
 
 ```bash
-TINYPILOT_DEBIAN_PACKAGE='tinypilot-00000000000000-1-armhf.deb'
-
 ansible-galaxy install git+https://github.com/tiny-pilot/ansible-role-tinypilot.git
-ansible-playbook example.yml \
-  --extra-vars "tinypilot_debian_package_path=${TINYPILOT_DEBIAN_PACKAGE}"
+ansible-playbook example.yml
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ Available variables are listed below, along with default values (see [defaults/m
 ```yaml
 tinypilot_group: tinypilot
 tinypilot_dir: /opt/tinypilot
-tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
-tinypilot_repo_branch: master
 tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0
+```
+
+Mandatory variables are listed below:
+
+```yaml
+# Specify the filesystem path or URL of a Debian package that installs
+# TinyPilot.
+tinypilot_debian_package_path: tinypilot-00000000000000-1-armhf.deb
 ```
 
 ## Dependencies
@@ -37,8 +43,11 @@ tinypilot_keyboard_interface: /dev/hidg0
 ### Running Example Playbook
 
 ```bash
+TINYPILOT_DEBIAN_PACKAGE='tinypilot-00000000000000-1-armhf.deb'
+
 ansible-galaxy install git+https://github.com/tiny-pilot/ansible-role-tinypilot.git
-ansible-playbook example.yml
+ansible-playbook example.yml \
+  --extra-vars "tinypilot_debian_package_path=${TINYPILOT_DEBIAN_PACKAGE}"
 ```
 
 ## Documentation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ tinypilot_privileged_dir: /opt/tinypilot-privileged
 # TinyPilot. If unset, the role installs TinyPilot from source using the
 # tinypilot_repo variable instead.
 tinypilot_debian_package_path: null
+# Installing TinyPilot via git has been DEPRECATED, in favor of the TinyPilot
+# Debian package. Set the tinypilot_debian_package_path variable instead.
+# https://github.com/tiny-pilot/ansible-role-tinypilot/issues/218
 tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
 tinypilot_repo_branch: master
 # Port on which TinyPilot frontend listens (accessible from other hosts on the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,7 +121,7 @@
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
 
-- name: get TinyPilot repo
+- name: '[DEPRECATED] get TinyPilot repo'
   # Don't escalate privileges because only the directory owner can use git.
   # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
   become: no


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/218
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/221"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>