### PR TITLE
Add support for uStreamer 5.x on Bullseye

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,8 @@ tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"
 # (Experimental): Install the Janus WebRTC server to enable uStreamer to stream
 # video over H264 instead of MJPEG.
 tinypilot_install_janus: no
+
+# uStreamer version to use on systems prior to Raspbian Bullseye (Debian 11).
+ustreamer_repo_version_legacy: v4.13
+# uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
+ustreamer_repo_version_modern: v5.22

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,4 +30,4 @@ tinypilot_install_janus: no
 # uStreamer version to use on systems prior to Raspbian Bullseye (Debian 11).
 ustreamer_repo_version_legacy: v4.13
 # uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
-ustreamer_repo_version_modern: v5.22
+ustreamer_repo_version_modern: v5.23

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -6,11 +6,14 @@
 - name: choose the default version of uStreamer to install
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_modern }}"
+  when: ustreamer_repo_version is not defined
 
 - name: override the target version of uStreamer with a legacy version for compatibility
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
-  when: tinypilot_is_os_raspbian and ((ansible_distribution_major_version | int) <= 10)
+  when: ((ustreamer_repo_version is not defined) and
+           tinypilot_is_os_raspbian and
+           ((ansible_distribution_major_version | int) <= 10))
 
 - name: import uStreamer role
   import_role:

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,7 +1,18 @@
 ---
+- name: choose the default version of uStreamer to install
+  set_fact:
+    ustreamer_repo_version: "{{ ustreamer_repo_version_modern }}"
+
+- name: override the target version of uStreamer with a legacy version for compatibility
+  set_fact:
+    ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
+  when: ansible_distribution == 'Debian' and ansible_distribution_major_version < 10
+
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
+  vars:
+    ustreamer_repo_version: "{{ ustreamer_repo_version }}"
 
 - name: create uStreamer Janus plugin config
   template:

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -15,8 +15,6 @@
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
-  vars:
-    ustreamer_repo_version: "{{ ustreamer_repo_version }}"
 
 - name: create uStreamer Janus plugin config
   template:

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,4 +1,8 @@
 ---
+- name: check if OS is Raspberry Pi OS
+  set_fact:
+    tinypilot_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
+
 - name: choose the default version of uStreamer to install
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_modern }}"
@@ -6,7 +10,7 @@
 - name: override the target version of uStreamer with a legacy version for compatibility
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
-  when: ansible_distribution == 'Debian' and ansible_distribution_major_version < 10
+  when: tinypilot_is_os_raspbian and ((ansible_distribution_major_version | int) <= 10)
 
 - name: import uStreamer role
   import_role:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,7 +10,6 @@ tinypilot_user: tinypilot
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
-ustreamer_repo_version: v4.13
 
 janus_deb_file: https://github.com/tiny-pilot/janus-debian/releases/download/1.0.1/janus_1.0.1-20220519_armhf.deb
 # These variables are only used within this role and don't affect the Janus


### PR DESCRIPTION
This change adjusts the version of the uStreamer dependency depending on the version of Debian running on the target system.

For GPU-based encoding (omx in Debian Buster and earlier, m2m in Debian Bullseye and later), there's complicated compatibility:

|                       | Debian Buster (and earlier) | Debian Bullseye |
|---------------|-----------------------------|-----------------|
| uStreamer 4.x | Full compatibility | omx-based encoding doesn't work |
| uStreamer 5.x | m2m-based encoding doesn't work | Full compatibility |

This change configures TinyPilot's dependency on uStreamer based on the OS version running on the target system so that we install 4.x for a Buster-based system and 5.x for a Bullseye-based system.

Tested successfully on Buster and Bullseye with a TC358743 capture chip.