### PR TITLE
Always choose a uStreamer repo version

### DIFF
--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -6,14 +6,12 @@
 - name: choose the default version of uStreamer to install
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_modern }}"
-  when: ustreamer_repo_version is not defined
 
 - name: override the target version of uStreamer with a legacy version for compatibility
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
-  when: ((ustreamer_repo_version is not defined) and
-           tinypilot_is_os_raspbian and
-           ((ansible_distribution_major_version | int) <= 10))
+  when: tinypilot_is_os_raspbian and
+          ((ansible_distribution_major_version | int) <= 10)
 
 - name: import uStreamer role
   import_role:


### PR DESCRIPTION
In dbb7ef75b529bb8bb2dae7d14054dcd76a129b66 we added compatibility with uStreamer 5.x by moving the ustreamer_repo_version variable from the vars folder to a set_fact play with a condition that the variable was undefined. This was to allow clients to override the ustreamer_repo_version variable through the --extra-vars flag.

It turns out that the import_role play has the surprising behavior of affecting plays that appear *before* it. Ansible apparently looks ahead in the playbook and pulls in variables from the ansible-role-ustreamer role and applies them to the ansible-role-tinypilot role. So ustreamer_repo_version was never undefined because it was inheriting the default value from ansible-role-ustreamer.

I tested it by trying to manually override ustreamer_repo_version with --extra-vars, which worked, but I didn't think to test the default behavior (no --extra-vars), which causes TinyPilot to install the master branch every time instead of picking a stable uStreamer release tag.

This has the drawback of preventing users from overriding ustreamer_repo_version with `--extra-vars`, but if we need that, we can figure out a different way of handling it.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/223"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>