### PR TITLE
Retrieve the uStreamer version from the binary instead of git

### DIFF
--- a/files/collect-debug-logs
+++ b/files/collect-debug-logs
@@ -71,7 +71,7 @@ cd /opt/tinypilot && \
 
 print_info "Checking uStreamer version..."
 cd /opt/ustreamer && \
-  printf "uStreamer version: %s %s\n" "$(git describe --tags --always)" "$(git rev-parse --short HEAD)" >> "${LOG_FILE}"
+  printf "uStreamer version: %s\n" "$(/opt/ustreamer/ustreamer --version)" >> "${LOG_FILE}"
 
 print_info "Checking OS version..."
 {


### PR DESCRIPTION
Versions of git with the 2022-04-12 security fix applied (https://github.blog/2022-04-12-git-security-vulnerability-announced/) will fail to check status if they're not run as the directory owner.

As a fix, we should just stop depending on git for the version number and use the output of ustreamer --version instead. This is also more flexible in the future if we decide to move from a source-compiled version to a precompiled Debian package for uStreamer.

Fixes https://github.com/tiny-pilot/tinypilot/issues/1140
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/231"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>