### PR TITLE
Override uStreamer variables in defaults instead of vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,7 @@ tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"
 ustreamer_repo_version_legacy: v4.13
 # uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
 ustreamer_repo_version_modern: v5.23
+
+ustreamer_interface: '127.0.0.1'
+ustreamer_port: 8001
+ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,9 @@ ustreamer_repo_version_legacy: v4.13
 # uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
 ustreamer_repo_version_modern: v5.23
 
+# By default, Ansible lets the child uStreamer role override these defaults, so
+# we have to apply a workaround in ustreamer.yml to prioritize our defaults
+# instead.
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ ustreamer_repo_version_modern: v5.23
 ustreamer_interface: '127.0.0.1'
 ustreamer_port: 8001
 ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git
+# If you add any new overrides for uStreamer default variables, add the variable
+# to tasks/ustreamer.yml as well.

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -13,9 +13,11 @@
   when: tinypilot_is_os_raspbian and
           ((ansible_distribution_major_version | int) <= 10)
 
-
+# Apply a workaround so that the default variables in this role take precedence
+# over the default variables in the child uStreamer role. This technique is
+# based on this example:
 # https://github.com/kzap/ansible-parent-role-defaults-example
-- name: override other uStreamer vars
+- name: collect uStreamer role variables to override
   set_fact:
     ustreamer_overrides: "{{ ustreamer_overrides | default({}) | combine({ item: lookup('vars', item) }) }}"
   when: lookup('vars', item, default='UNDEFINED_VARIABLE') != 'UNDEFINED_VARIABLE'
@@ -25,7 +27,7 @@
     - ustreamer_repo
 
 - name: import uStreamer role
-  import_role:
+  include_role:
     name: ansible-role-ustreamer
   vars:
       ustreamer_interface: "{{ ustreamer_overrides.ustreamer_interface }}"

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -13,12 +13,16 @@
   when: tinypilot_is_os_raspbian and
           ((ansible_distribution_major_version | int) <= 10)
 
+
+# https://github.com/kzap/ansible-parent-role-defaults-example
 - name: override other uStreamer vars
   set_fact:
-    ustreamer_overrides:
-      ustreamer_interface: "{{ ustreamer_interface }}"
-      ustreamer_port: "{{ ustreamer_port }}"
-      ustreamer_repo: "{{ ustreamer_repo }}"
+    ustreamer_overrides: "{{ ustreamer_overrides | default({}) | combine({ item: lookup('vars', item) }) }}"
+  when: lookup('vars', item, default='UNDEFINED_VARIABLE') != 'UNDEFINED_VARIABLE'
+  loop:
+    - ustreamer_interface
+    - ustreamer_port
+    - ustreamer_repo
 
 - name: import uStreamer role
   import_role:

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -13,6 +13,17 @@
   when: tinypilot_is_os_raspbian and
           ((ansible_distribution_major_version | int) <= 10)
 
+- name: override other uStreamer vars
+  set_fact:
+    ustreamer_overrides:
+      ustreamer_interface: "{{ ustreamer_interface }}"
+      ustreamer_port: "{{ ustreamer_port }}"
+      ustreamer_repo: "{{ ustreamer_repo }}"
+
 - name: import uStreamer role
   import_role:
     name: ansible-role-ustreamer
+  vars:
+      ustreamer_interface: "{{ ustreamer_overrides.ustreamer_interface }}"
+      ustreamer_port: "{{ ustreamer_overrides.ustreamer_port }}"
+      ustreamer_repo: "{{ ustreamer_overrides.ustreamer_repo }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,10 +3,3 @@
 # updates) relies on the tinypilot user being named "tinypilot" so changing this
 # value will break updates.
 tinypilot_user: tinypilot
-
-# uStreamer variables are placed here, instead of in `defaults/main.yml`,
-# in order to elevate their variable precedence. These variables will now
-# override the default variables in the uStreamer role.
-ustreamer_interface: '127.0.0.1'
-ustreamer_port: 8001
-ustreamer_repo: https://github.com/tiny-pilot/ustreamer.git


### PR DESCRIPTION
I found an example that demonstrated how to override a child role's default vars with the parent role's defaults:

https://github.com/kzap/ansible-parent-role-defaults-example

This is a little better for us, as `vars` is too high a precedence and paints us into a corner in other ways.

The downside is that we have to switch the uStreamer role import from a static import (`import_role`) to a dynamic import (`include_role`).

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/235"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>