### PR TITLE
Provide complete vars to uStreamer role when updating video settings

### DIFF
--- a/files/update-video-settings
+++ b/files/update-video-settings
@@ -72,5 +72,6 @@ echo "- hosts: localhost
 ansible-playbook \
   "${PLAYBOOK}" \
   --inventory localhost, \
+  --extra-vars "@${INSTALLER_DIR}/roles/ansible-role-tinypilot/vars/main.yml" \
   --extra-vars "${EXTRA_VARS_PATH}" \
   --tags "systemd-config"


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-tinypilot/issues/237 by additionally passing on the parameters from `vars/main.yml` to the uStreamer role, when updating the video settings.

I’m not sure this is the cleanest solution to the problem, but to me it would seem good enough for now. An alternative approach could be to not execute `ansible-role-ustreamer` directly, but to have a task in `ansible-role-tinypilot` that’s like “update video settings”. That way we wouldn’t have to manually recreate the runtime environment, which obviously is prone to subtle bugs. But that might have other implications, such as degraded performance.

Note: the second `--extra-vars` seems to take precedence over the former. I [couldn’t find that stated in the Ansible docs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-at-runtime), so I just tried it out.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/238"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>