### PR TITLE
Change target uStreamer version to 5.29 on Bullseye

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,4 +27,4 @@ tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"
 # uStreamer version to use on systems prior to Raspbian Bullseye (Debian 11).
 ustreamer_repo_version_legacy: v4.13
 # uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
-ustreamer_repo_version_modern: v5.23
+ustreamer_repo_version_modern: v5.29


### PR DESCRIPTION
5.29 includes a fix to enable audio support with the version of Janus that TinyPilot uses.

https://github.com/pikvm/ustreamer/pull/182

Audio won't work out of the box with this role (and it won't work at all on hardware that doesn't support audio), but this change gets us closer to audio support.

Note that uStreamer 5.30 is now available, but it includes changes that don't seem relevant to our current needs, and 5.29 is the latest version I've tested.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/239"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>