### PR TITLE
Remove Janus CircleCI hack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,6 @@ jobs:
           name: Create Python3 virtual environment
           command: python3 -m venv venv
       - run:
-          # The Janus Debian package doesn’t support the architecture of the
-          # testing environment on CircleCI. Therefore, we have to alter the
-          # Ansible config to prevent the uStreamer role from trying to install
-          # Janus during the tests.
-          # https://github.com/tiny-pilot/ansible-role-tinypilot/issues/236
-          name: Overwrite `ustreamer_h264_...` variables
-          command: |
-            sed --in-place \
-              's/ustreamer_h264_\(.*\): .*/ustreamer_h264_\1: null/g' \
-              vars/main.yml
-      - run:
           name: Test role with molecule
           command: |
             . venv/bin/activate && \

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,4 +1,3 @@
 ---
 - src: https://github.com/tiny-pilot/ansible-role-ustreamer
-  version: apt-get-janus
 - src: https://github.com/tiny-pilot/ansible-role-nginx

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,4 +1,3 @@
 ---
 - src: https://github.com/tiny-pilot/ansible-role-ustreamer
-  version: idempotence
 - src: https://github.com/tiny-pilot/ansible-role-nginx

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,3 +1,4 @@
 ---
 - src: https://github.com/tiny-pilot/ansible-role-ustreamer
+  version: idempotence
 - src: https://github.com/tiny-pilot/ansible-role-nginx

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,3 +1,4 @@
 ---
 - src: https://github.com/tiny-pilot/ansible-role-ustreamer
+  version: apt-get-janus
 - src: https://github.com/tiny-pilot/ansible-role-nginx

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,9 +3,14 @@
   hosts: all
   gather_facts: no
   tasks:
-    - name: Update apt cache & install system dependencies
+    - name: Update apt cache and install system dependencies
       apt:
-        name: lsb-release
+        name:
+          # To accurately detect the OS of the target machine, we need to
+          # install the lsb-release package before Ansible gathers facts. This
+          # ensures that the ansible_lsb fact is defined.
+          # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#conditionals-based-on-ansible-facts
+          - lsb-release
         update_cache: true
         cache_valid_time: 600
     - name: Gather facts

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,11 +1,15 @@
 ---
 - name: Converge
   hosts: all
+  gather_facts: no
   tasks:
-    - name: Update apt cache
+    - name: Update apt cache & install system dependencies
       apt:
+        name: lsb-release
         update_cache: true
         cache_valid_time: 600
+    - name: Gather facts
+      setup:
     - name: "Include ansible-role-tinypilot"
       include_role:
         name: "ansible-role-tinypilot"

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -1,5 +1,5 @@
 ---
-- name: check if OS is Raspberry Pi OS
+- name: detect OS
   set_fact:
     tinypilot_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
     tinypilot_is_os_debian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Debian' }}"

--- a/tasks/ustreamer.yml
+++ b/tasks/ustreamer.yml
@@ -2,6 +2,7 @@
 - name: check if OS is Raspberry Pi OS
   set_fact:
     tinypilot_is_os_raspbian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Raspbian' }}"
+    tinypilot_is_os_debian: "{{ ansible_lsb.id is defined and ansible_lsb.id == 'Debian' }}"
 
 - name: choose the default version of uStreamer to install
   set_fact:
@@ -10,7 +11,7 @@
 - name: override the target version of uStreamer with a legacy version for compatibility
   set_fact:
     ustreamer_repo_version: "{{ ustreamer_repo_version_legacy }}"
-  when: tinypilot_is_os_raspbian and
+  when: (tinypilot_is_os_raspbian or tinypilot_is_os_debian) and
           ((ansible_distribution_major_version | int) <= 10)
 
 - name: import uStreamer role


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-ustreamer/issues/77
Dependent on https://github.com/tiny-pilot/ansible-role-ustreamer/pull/78
Resolves https://github.com/tiny-pilot/ansible-role-tinypilot/issues/236

### Notes:
1. I had to make the majority of changes in https://github.com/tiny-pilot/ansible-role-ustreamer/pull/78 to get this branch to build. I still need to [remove this ustreamer version pin](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/a6889cbbb4aa3b9bcee1cce8cccc1d7f78a36c63/meta/requirements.yml#L3).
1. It turns out that ustreamer fails to compile `WITH_JANUS=1` even on Debian Buster (not just Raspberry Pi OS Buster). So I [forced a legacy uStreamer version on Debian Buster](https://github.com/tiny-pilot/ansible-role-tinypilot/blob/a6889cbbb4aa3b9bcee1cce8cccc1d7f78a36c63/tasks/ustreamer.yml#L14-L15) too.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/240"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>