### PR TITLE
Remove legacy nginx vhosts cleanup.

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,12 +1,4 @@
 ---
-# TinyPilot Pro has two nginx configuration files, whereas TinyPilot Community
-# has just one. Remove the extra Pro file otherwise nginx will fail due to the
-# extra file if the user downgrades from Pro to free.
-- name: remove stray conf file from TinyPilot Pro
-  file:
-    path: /etc/nginx/sites-enabled/tinypilot.http.conf
-    state: absent
-
 - name: import nginx role
   import_role:
     name: ansible-role-nginx


### PR DESCRIPTION
Resolves https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/132

This PR depends on first resolving https://github.com/tiny-pilot/gatekeeper/issues/83

Now that TinyPilot Community/Pro users are forced to upgrade to `1.8.0`/`2.5.0` (before upgrading any further), we can remove legacy cleanup code.

The `ansible-role-tinypilot-pro` version of this PR (i.e., merging community changes) would be to remove [this ansible task](https://github.com/tiny-pilot/ansible-role-tinypilot-pro/blob/1ce12942a5ef711f5481d8600a321c6c54f43cc4/tasks/nginx.yml#L11-L18).
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/244"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>