### PR TITLE
Upgrade the target uStreamer version to 5.34 on Bullseye systems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,4 +25,4 @@ tinypilot_app_settings_file: "/home/{{ tinypilot_user }}/app_settings.cfg"
 # uStreamer version to use on systems prior to Raspbian Bullseye (Debian 11).
 ustreamer_repo_version_legacy: v4.13
 # uStreamer version to use on Raspbian Bullseye (Debian 11) or later systems.
-ustreamer_repo_version_modern: v5.29
+ustreamer_repo_version_modern: v5.34


### PR DESCRIPTION
A user reported an H264 bug that's likely fixed in the latest version of uStreamer, so let's grab the latest and greatest version available. https://github.com/tiny-pilot/tinypilot/issues/1237#issuecomment-1361410364
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/246"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>