### PR TITLE
Add a workaround for git permissions restrictions

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,11 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    hosts:
+      all:
+        vars:
+          ansible_user: root
 verifier:
   name: ansible
 scenario:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,11 +21,6 @@ platforms:
 provisioner:
   name: ansible
   log: true
-  inventory:
-    hosts:
-      all:
-        vars:
-          ansible_user: root
 verifier:
   name: ansible
 scenario:

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -1,0 +1,23 @@
+# Installing TinyPilot via git is deprecated and no longer used for production
+# installs, but we still rely on it for testing the Ansible role.
+- name: create TinyPilot folder
+  file:
+    path: "{{ tinypilot_dir }}"
+    state: directory
+    owner: "{{ tinypilot_user }}"
+    group: "{{ tinypilot_group }}"
+
+- name: suppress warnings about git ownership for TinyPilot directory
+  git_config:
+    scope: global
+    name: safe.directory
+    value: "{{ tinypilot_dir }}"
+
+- name: '[DEPRECATED] get TinyPilot repo'
+  git:
+    repo: "{{ tinypilot_repo }}"
+    dest: "{{ tinypilot_dir }}"
+    version: "{{ tinypilot_repo_branch }}"
+    accept_hostkey: yes
+  notify:
+    - restart TinyPilot service

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -1,5 +1,32 @@
+
 # Installing TinyPilot via git is deprecated and no longer used for production
 # installs, but we still rely on it for testing the Ansible role.
+
+- name: collect TinyPilot required apt packages on all systems
+  set_fact:
+    tinypilot_packages:
+      - git
+      - python3-venv
+      - sudo
+    can_install_pip3: >-
+      {{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('11', '>='))
+         or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')) }}
+
+- name: add pip to required apt packages
+  set_fact:
+    tinypilot_packages: "{{ tinypilot_packages }} + ['python-pip']"
+  when: not can_install_pip3
+
+- name: add pip3 to required apt packages
+  set_fact:
+    tinypilot_packages: "{{ tinypilot_packages }} + ['python3-pip']"
+  when: can_install_pip3
+
+- name: install TinyPilot pre-requisite packages
+  apt:
+    name: "{{ tinypilot_packages }}"
+    state: present
+
 - name: create TinyPilot folder
   file:
     path: "{{ tinypilot_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,11 @@
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
 
+- git_config:
+    scope: global
+    name: safe.directory
+    value: "{{ tinypilot_dir }}"
+
 - name: '[DEPRECATED] get TinyPilot repo'
   # Don't escalate privileges because only the directory owner can use git.
   # Issue: https://github.com/tiny-pilot/tinypilot/issues/963

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,37 +68,9 @@
     deb: "{{ tinypilot_debian_package_path }}"
   when: tinypilot_debian_package_path != None
 
-- name: create TinyPilot folder
-  file:
-    path: "{{ tinypilot_dir }}"
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    recurse: yes
-  when: tinypilot_debian_package_path == None
-  tags:
-    # This fails the idempotency test because it must run on every provision
-    # to set the correct directory ownership that allows git to sync.
-    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
-    - molecule-idempotence-notest
-
-- git_config:
-    scope: global
-    name: safe.directory
-    value: "{{ tinypilot_dir }}"
-
-- name: '[DEPRECATED] get TinyPilot repo'
-  # Don't escalate privileges because only the directory owner can use git.
-  # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
-  become: no
-  git:
-    repo: "{{ tinypilot_repo }}"
-    dest: "{{ tinypilot_dir }}"
-    version: "{{ tinypilot_repo_branch }}"
-    accept_hostkey: yes
-  when: tinypilot_debian_package_path == None
-  notify:
-    - restart TinyPilot service
+- name: install TinyPilot via git
+  import_tasks: install_tinypilot_git.yml
+  when: tinypilot_debian_package_path != None
 
 - name: find absolute path to python3
   shell: realpath $(which python3)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,32 +25,6 @@
 - name: install HID USB gadget
   import_tasks: install_usb_gadget.yml
 
-- name: collect TinyPilot required apt packages on all systems
-  set_fact:
-    tinypilot_packages:
-      - git
-      - python3-venv
-      - sudo
-    can_install_pip3: >-
-      {{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('11', '>='))
-         or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')) }}
-
-- name: add pip to required apt packages
-  set_fact:
-    tinypilot_packages: "{{ tinypilot_packages }} + ['python-pip']"
-  when: not can_install_pip3
-
-- name: add pip3 to required apt packages
-  set_fact:
-    tinypilot_packages: "{{ tinypilot_packages }} + ['python3-pip']"
-  when: can_install_pip3
-
-- name: install TinyPilot pre-requisite packages
-  apt:
-    name: "{{ tinypilot_packages }}"
-    state: present
-  when: tinypilot_debian_package_path == None
-
 - name: create tinypilot group
   group:
     name: "{{ tinypilot_group }}"
@@ -70,7 +44,7 @@
 
 - name: install TinyPilot via git
   import_tasks: install_tinypilot_git.yml
-  when: tinypilot_debian_package_path != None
+  when: tinypilot_debian_package_path == None
 
 - name: find absolute path to python3
   shell: realpath $(which python3)


### PR DESCRIPTION
In #197, we adjusted the TinyPilot directory's permissions to work around a git security fix:

> This is needed to allow git to sync after the announced [git security fix](https://github.blog/2022-04-12-git-security-vulnerability-announced/).
> 
> > By default, Git will refuse to even parse a Git config of a repository owned by someone else

We were conservative about overriding the security fix at the time because we still used git to install TinyPilot. Now, we only use the git-based install for testing, so we can be more aggressive about disabling the security setting.

I'm not sure why the previous fix suddenly stopped working, but it's not worth investigating at this point given that this flow is only used for testing.
<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/247"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>