### PR TITLE
Add a workaround for git permissions restrictions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,8 +72,6 @@
   file:
     path: "{{ tinypilot_dir }}"
     state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
     recurse: yes
   when: tinypilot_debian_package_path == None
   tags:
@@ -82,10 +80,14 @@
     # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
     - molecule-idempotence-notest
 
+- name: suppress warnings about git ownership for TinyPilot directory
+  git_config:
+    scope: global
+    name: safe.directory
+    value: "{{ tinypilot_dir }}"
+  when: tinypilot_debian_package_path == None
+
 - name: '[DEPRECATED] get TinyPilot repo'
-  # Don't escalate privileges because only the directory owner can use git.
-  # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
-  become: no
   git:
     repo: "{{ tinypilot_repo }}"
     dest: "{{ tinypilot_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,13 +72,7 @@
   file:
     path: "{{ tinypilot_dir }}"
     state: directory
-    recurse: yes
   when: tinypilot_debian_package_path == None
-  tags:
-    # This fails the idempotency test because it must run on every provision
-    # to set the correct directory ownership that allows git to sync.
-    # Issue: https://github.com/tiny-pilot/tinypilot/issues/963
-    - molecule-idempotence-notest
 
 - name: suppress warnings about git ownership for TinyPilot directory
   git_config:


### PR DESCRIPTION
In #197, we adjusted the TinyPilot directory's permissions to work around a git security fix:

> This is needed to allow git to sync after the announced [git security fix](https://github.blog/2022-04-12-git-security-vulnerability-announced/).
> 
> > By default, Git will refuse to even parse a Git config of a repository owned by someone else

We were conservative about overriding the security fix at the time because we still used git to install TinyPilot. Now, we only use the git-based install for testing, so we can be more aggressive about disabling the security setting.

I'm not sure why the previous fix suddenly stopped working, but it's not worth investigating at this point given that this flow is only used for testing.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/248"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>