### PR TITLE
Refactor git install

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,11 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    hosts:
+      all:
+        vars:
+          ansible_user: root
 verifier:
   name: ansible
 scenario:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,11 +21,6 @@ platforms:
 provisioner:
   name: ansible
   log: true
-  inventory:
-    hosts:
-      all:
-        vars:
-          ansible_user: root
 verifier:
   name: ansible
 scenario:

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -1,4 +1,3 @@
-
 # Installing TinyPilot via git is deprecated and no longer used for production
 # installs, but we still rely on it for testing the Ansible role.
 

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -1,0 +1,23 @@
+# Installing TinyPilot via git is deprecated and no longer used for production
+# installs, but we still rely on it for testing the Ansible role.
+- name: create TinyPilot folder
+  file:
+    path: "{{ tinypilot_dir }}"
+    state: directory
+    owner: "{{ tinypilot_user }}"
+    group: "{{ tinypilot_group }}"
+
+- name: suppress warnings about git ownership for TinyPilot directory
+  git_config:
+    scope: global
+    name: safe.directory
+    value: "{{ tinypilot_dir }}"
+
+- name: '[DEPRECATED] get TinyPilot repo'
+  git:
+    repo: "{{ tinypilot_repo }}"
+    dest: "{{ tinypilot_dir }}"
+    version: "{{ tinypilot_repo_branch }}"
+    accept_hostkey: yes
+  notify:
+    - restart TinyPilot service

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -1,5 +1,32 @@
+
 # Installing TinyPilot via git is deprecated and no longer used for production
 # installs, but we still rely on it for testing the Ansible role.
+
+- name: collect TinyPilot required apt packages on all systems
+  set_fact:
+    tinypilot_packages:
+      - git
+      - python3-venv
+      - sudo
+    can_install_pip3: >-
+      {{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('11', '>='))
+         or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')) }}
+
+- name: add pip to required apt packages
+  set_fact:
+    tinypilot_packages: "{{ tinypilot_packages }} + ['python-pip']"
+  when: not can_install_pip3
+
+- name: add pip3 to required apt packages
+  set_fact:
+    tinypilot_packages: "{{ tinypilot_packages }} + ['python3-pip']"
+  when: can_install_pip3
+
+- name: install TinyPilot pre-requisite packages
+  apt:
+    name: "{{ tinypilot_packages }}"
+    state: present
+
 - name: create TinyPilot folder
   file:
     path: "{{ tinypilot_dir }}"

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -31,8 +31,6 @@
   file:
     path: "{{ tinypilot_dir }}"
     state: directory
-    owner: "{{ tinypilot_user }}"
-    group: "{{ tinypilot_group }}"
 
 - name: suppress warnings about git ownership for TinyPilot directory
   git_config:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,11 @@
     value: "{{ tinypilot_dir }}"
   when: tinypilot_debian_package_path == None
 
+- git_config:
+    scope: global
+    name: safe.directory
+    value: "{{ tinypilot_dir }}"
+
 - name: '[DEPRECATED] get TinyPilot repo'
   git:
     repo: "{{ tinypilot_repo }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,33 +68,9 @@
     deb: "{{ tinypilot_debian_package_path }}"
   when: tinypilot_debian_package_path != None
 
-- name: create TinyPilot folder
-  file:
-    path: "{{ tinypilot_dir }}"
-    state: directory
-  when: tinypilot_debian_package_path == None
-
-- name: suppress warnings about git ownership for TinyPilot directory
-  git_config:
-    scope: global
-    name: safe.directory
-    value: "{{ tinypilot_dir }}"
-  when: tinypilot_debian_package_path == None
-
-- git_config:
-    scope: global
-    name: safe.directory
-    value: "{{ tinypilot_dir }}"
-
-- name: '[DEPRECATED] get TinyPilot repo'
-  git:
-    repo: "{{ tinypilot_repo }}"
-    dest: "{{ tinypilot_dir }}"
-    version: "{{ tinypilot_repo_branch }}"
-    accept_hostkey: yes
-  when: tinypilot_debian_package_path == None
-  notify:
-    - restart TinyPilot service
+- name: install TinyPilot via git
+  import_tasks: install_tinypilot_git.yml
+  when: tinypilot_debian_package_path != None
 
 - name: find absolute path to python3
   shell: realpath $(which python3)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,32 +25,6 @@
 - name: install HID USB gadget
   import_tasks: install_usb_gadget.yml
 
-- name: collect TinyPilot required apt packages on all systems
-  set_fact:
-    tinypilot_packages:
-      - git
-      - python3-venv
-      - sudo
-    can_install_pip3: >-
-      {{ (ansible_distribution == 'Debian' and ansible_distribution_version is version('11', '>='))
-         or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '>=')) }}
-
-- name: add pip to required apt packages
-  set_fact:
-    tinypilot_packages: "{{ tinypilot_packages }} + ['python-pip']"
-  when: not can_install_pip3
-
-- name: add pip3 to required apt packages
-  set_fact:
-    tinypilot_packages: "{{ tinypilot_packages }} + ['python3-pip']"
-  when: can_install_pip3
-
-- name: install TinyPilot pre-requisite packages
-  apt:
-    name: "{{ tinypilot_packages }}"
-    state: present
-  when: tinypilot_debian_package_path == None
-
 - name: create tinypilot group
   group:
     name: "{{ tinypilot_group }}"
@@ -70,7 +44,7 @@
 
 - name: install TinyPilot via git
   import_tasks: install_tinypilot_git.yml
-  when: tinypilot_debian_package_path != None
+  when: tinypilot_debian_package_path == None
 
 - name: find absolute path to python3
   shell: realpath $(which python3)


### PR DESCRIPTION
At this point, we have a lot of tasks that only run on the git-based TinyPilot install flow, which only happens in CI. This change refactors those tasks into their own playbook to unclutter the production playbook.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/249"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>