### PR TITLE
Only add tinypilot user and group in git-based install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Ansible role for [TinyPilot KVM](https://github.com/tiny-pilot/tinypilot).
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_group: tinypilot
 tinypilot_repo: https://github.com/tiny-pilot/tinypilot.git
 tinypilot_repo_branch: master
 tinypilot_interface: '127.0.0.1'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-tinypilot_group: tinypilot
 # Specifies the filesystem path or URL of a Debian package that installs
 # TinyPilot. If unset, the role installs TinyPilot from source using the
 # tinypilot_repo variable instead.

--- a/tasks/install_tinypilot_git.yml
+++ b/tasks/install_tinypilot_git.yml
@@ -45,3 +45,15 @@
     accept_hostkey: yes
   notify:
     - restart TinyPilot service
+
+- name: create tinypilot group
+  group:
+    name: "{{ tinypilot_group }}"
+    state: present
+
+- name: create tinypilot user
+  user:
+    name: "{{ tinypilot_user }}"
+    group: "{{ tinypilot_group }}"
+    system: yes
+    create_home: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,18 +25,6 @@
 - name: install HID USB gadget
   import_tasks: install_usb_gadget.yml
 
-- name: create tinypilot group
-  group:
-    name: "{{ tinypilot_group }}"
-    state: present
-
-- name: create tinypilot user
-  user:
-    name: "{{ tinypilot_user }}"
-    group: "{{ tinypilot_group }}"
-    system: yes
-    create_home: yes
-
 - name: install TinyPilot Debian package
   apt:
     deb: "{{ tinypilot_debian_package_path }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,7 @@
 # updates) relies on the tinypilot user being named "tinypilot" so changing this
 # value will break updates.
 tinypilot_user: tinypilot
+tinypilot_group: tinypilot
 
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged


### PR DESCRIPTION
https://github.com/tiny-pilot/tinypilot/pull/1240

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/250"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>