### PR TITLE
Skip installing tinypilot user and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Ansible role for [TinyPilot KVM](https://github.com/tiny-pilot/tinypilot).
 Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
 ```yaml
-tinypilot_group: tinypilot
 tinypilot_interface: '127.0.0.1'
 tinypilot_port: 8000
 tinypilot_keyboard_interface: /dev/hidg0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-tinypilot_group: tinypilot
 # Specifies the filesystem path or URL of a Debian package that installs
 # TinyPilot.
 tinypilot_debian_package_path: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,18 +25,6 @@
 - name: install HID USB gadget
   import_tasks: install_usb_gadget.yml
 
-- name: create tinypilot group
-  group:
-    name: "{{ tinypilot_group }}"
-    state: present
-
-- name: create tinypilot user
-  user:
-    name: "{{ tinypilot_user }}"
-    group: "{{ tinypilot_group }}"
-    system: yes
-    create_home: yes
-
 - name: install TinyPilot Debian package
   apt:
     deb: "{{ tinypilot_debian_package_path }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,7 @@
 # updates) relies on the tinypilot user being named "tinypilot" so changing this
 # value will break updates.
 tinypilot_user: tinypilot
+tinypilot_group: tinypilot
 
 tinypilot_dir: /opt/tinypilot
 tinypilot_privileged_dir: /opt/tinypilot-privileged


### PR DESCRIPTION
It's faster/simpler to create the `tinypilot` user and group in the Debian package as opposed to the Ansible role.

https://github.com/tiny-pilot/tinypilot/pull/1240 makes the corresponding change to the TinyPilot Debian package.

The ansible role still references the `tinypilot_group` variable, so we can't remove it entirely yet, but this change moves it to `vars` to hint to clients that it's not a variable they should change.

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/ansible-role-tinypilot/252"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>